### PR TITLE
Add validation for unclosed toggle sections and out-of-range line numbers

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -309,14 +309,23 @@ pub fn find_and_toggle_section(
             let section_start = i + 1;
 
             let end_marker = format!("toggle:end ID={}", section_id);
-            let mut section_end = lines.len();
+            let mut section_end = None;
 
             for (j, line) in lines.iter().enumerate().skip(i + 1) {
                 if line.contains(&end_marker) {
-                    section_end = j;
+                    section_end = Some(j);
                     break;
                 }
             }
+
+            let section_end = match section_end {
+                Some(end) => end,
+                None => {
+                    return Err(
+                        UsageError(format!("Unclosed section ID={}", section_id)).into()
+                    );
+                }
+            };
 
             if section_end > section_start {
                 let force_mode = force.as_deref();

--- a/src/core.rs
+++ b/src/core.rs
@@ -346,7 +346,7 @@ pub fn find_and_toggle_section(
                     toggled_lines.pop();
                 }
                 let section_len = section_end - section_start;
-                debug_assert_eq!(
+                assert_eq!(
                     toggled_lines.len(),
                     section_len,
                     "Toggled line count ({}) must match section span ({})",

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,14 @@ fn toggle_line_range(
         ))
         .into());
     }
+    if end_line > line_count {
+        return Err(UsageError(format!(
+            "End line {} is out of range (file has {} lines)",
+            end_line,
+            line_count
+        ))
+        .into());
+    }
 
     let range = core::LineRange::new(start_line, end_line);
     let force_mode = force.as_deref();


### PR DESCRIPTION
## Summary
This PR improves error handling and validation in the toggle section functionality by detecting unclosed toggle sections and validating line number ranges.

## Key Changes
- **Unclosed section detection**: Changed `section_end` from defaulting to `lines.len()` to using `Option<usize>`, allowing detection of missing end markers. Now returns a `UsageError` when a toggle section is not properly closed with a matching end marker.
- **Line range validation**: Added validation in `toggle_line_range()` to ensure the end line number doesn't exceed the file's line count, returning a descriptive error if it does.
- **Debug assertion upgrade**: Changed `debug_assert_eq!` to `assert_eq!` for the toggled line count validation to catch potential logic errors in production builds.

## Implementation Details
- The section end marker search now explicitly tracks whether a match was found using `Option::Some()`, making the intent clearer and preventing silent failures when end markers are missing.
- Error messages provide context about what went wrong (e.g., "Unclosed section ID=..." or "End line X is out of range (file has Y lines)").
- These validations prevent undefined behavior and provide better user feedback when toggle sections are malformed.

https://claude.ai/code/session_01HcRsH68X9u2AVQUfCQP4AQ