### PR TITLE
Add JSON output, encoding support, EOL normalization, and symlink handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ similar = "2"
 toml = "0.8"
 # Serialization/deserialization
 serde = { version = "1", features = ["derive"] }
+# JSON output
+serde_json = "1"
+# Encoding support
+encoding_rs = "0.8"
 
 [dev-dependencies]
 # For benchmarking

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,10 +29,12 @@ pub struct LanguageConfig {
 impl ToggleConfig {
     /// Load a toggle config from a TOML file.
     pub fn load(path: &Path) -> anyhow::Result<Self> {
-        let content = std::fs::read_to_string(path)
-            .map_err(|e| anyhow::anyhow!("Failed to read config file '{}': {}", path.display(), e))?;
-        let config: ToggleConfig = toml::from_str(&content)
-            .map_err(|e| anyhow::anyhow!("Failed to parse config file '{}': {}", path.display(), e))?;
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            anyhow::anyhow!("Failed to read config file '{}': {}", path.display(), e)
+        })?;
+        let config: ToggleConfig = toml::from_str(&content).map_err(|e| {
+            anyhow::anyhow!("Failed to parse config file '{}': {}", path.display(), e)
+        })?;
         Ok(config)
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -165,6 +165,7 @@ fn toggle_comments_inner(
             }
         };
 
+        #[allow(clippy::needless_range_loop)]
         for idx in start..end {
             if protected.contains(&idx) {
                 continue;
@@ -180,24 +181,22 @@ fn toggle_comments_inner(
 
             if should_comment {
                 // Strip existing comment marker first to avoid double-commenting
-                let stripped = {
-                    let marker_space = format!("{} ", marker);
-                    if rest.starts_with(&marker_space) {
-                        &rest[marker_space.len()..]
-                    } else if rest.starts_with(marker) {
-                        &rest[marker.len()..]
-                    } else {
-                        rest
-                    }
+                let marker_space = format!("{} ", marker);
+                let stripped = if let Some(s) = rest.strip_prefix(&marker_space) {
+                    s
+                } else if let Some(s) = rest.strip_prefix(marker) {
+                    s
+                } else {
+                    rest
                 };
                 lines[idx] = format!("{}{} {}", leading_ws, marker, stripped);
             } else {
                 // Uncomment: remove marker and optional following space
                 let marker_space = format!("{} ", marker);
-                if rest.starts_with(&marker_space) {
-                    lines[idx] = format!("{}{}", leading_ws, &rest[marker_space.len()..]);
-                } else if rest.starts_with(marker) {
-                    lines[idx] = format!("{}{}", leading_ws, &rest[marker.len()..]);
+                if let Some(s) = rest.strip_prefix(&marker_space) {
+                    lines[idx] = format!("{}{}", leading_ws, s);
+                } else if let Some(s) = rest.strip_prefix(marker) {
+                    lines[idx] = format!("{}{}", leading_ws, s);
                 }
             }
         }
@@ -273,16 +272,35 @@ pub fn get_comment_style(
 
     let mut comment_styles = HashMap::new();
     // Hash-style comments
-    for ext in &["py", "sh", "rb", "yaml", "yml", "toml", "r", "ex", "exs", "pl", "pm"] {
-        comment_styles.insert(*ext, CommentStyle { single_line: "#".to_string() });
+    for ext in &[
+        "py", "sh", "rb", "yaml", "yml", "toml", "r", "ex", "exs", "pl", "pm",
+    ] {
+        comment_styles.insert(
+            *ext,
+            CommentStyle {
+                single_line: "#".to_string(),
+            },
+        );
     }
     // Slash-style comments
-    for ext in &["js", "jsx", "ts", "tsx", "rs", "java", "c", "cpp", "go", "swift", "kt", "scala", "php"] {
-        comment_styles.insert(*ext, CommentStyle { single_line: "//".to_string() });
+    for ext in &[
+        "js", "jsx", "ts", "tsx", "rs", "java", "c", "cpp", "go", "swift", "kt", "scala", "php",
+    ] {
+        comment_styles.insert(
+            *ext,
+            CommentStyle {
+                single_line: "//".to_string(),
+            },
+        );
     }
     // Dash-style comments
     for ext in &["lua", "hs", "sql"] {
-        comment_styles.insert(*ext, CommentStyle { single_line: "--".to_string() });
+        comment_styles.insert(
+            *ext,
+            CommentStyle {
+                single_line: "--".to_string(),
+            },
+        );
     }
 
     comment_styles
@@ -294,7 +312,7 @@ pub fn get_comment_style(
 /// Find section markers and toggle the content between them.
 /// Returns true if the file was modified.
 pub fn find_and_toggle_section(
-    lines: &mut Vec<String>,
+    lines: &mut [String],
     section_id: &str,
     force: &Option<String>,
     comment_style: &CommentStyle,

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -34,11 +34,11 @@ impl ExitCode {
     /// Map to sysexits.h values for --posix-exit
     pub fn posix(self) -> i32 {
         match self {
-            Self::Success => 0,    // EX_OK
-            Self::Usage => 64,     // EX_USAGE
-            Self::IoError => 74,   // EX_IOERR
+            Self::Success => 0,      // EX_OK
+            Self::Usage => 64,       // EX_USAGE
+            Self::IoError => 74,     // EX_IOERR
             Self::ToggleError => 70, // EX_SOFTWARE
-            Self::Internal => 71,  // EX_OSERR
+            Self::Internal => 71,    // EX_OSERR
         }
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,12 +1,12 @@
 // File I/O operations for the Toggle CLI
 
+use similar::TextDiff;
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use similar::TextDiff;
 use tempfile::NamedTempFile;
 
-/// Read file content with encoding detection
+/// Read file content as UTF-8.
 pub fn read_file(path: &Path) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut content = String::new();
@@ -14,28 +14,153 @@ pub fn read_file(path: &Path) -> io::Result<String> {
     Ok(content)
 }
 
+/// Read file content with a specified encoding.
+/// Supports any encoding label recognized by the Encoding Standard
+/// (e.g., "utf-8", "latin-1", "iso-8859-1", "windows-1252", "ascii").
+pub fn read_file_encoded(path: &Path, encoding: &str) -> io::Result<String> {
+    if encoding.eq_ignore_ascii_case("utf-8") {
+        return read_file(path);
+    }
+    let bytes = std::fs::read(path)?;
+    let enc = resolve_encoding(encoding)?;
+    let (decoded, _, had_errors) = enc.decode(&bytes);
+    if had_errors {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Failed to decode file as {}", encoding),
+        ));
+    }
+    Ok(decoded.into_owned())
+}
+
+/// Resolve an encoding label to an encoding_rs::Encoding.
+/// Handles common aliases like "latin-1" that encoding_rs doesn't directly recognize.
+fn resolve_encoding(label: &str) -> io::Result<&'static encoding_rs::Encoding> {
+    // Try direct lookup first
+    if let Some(enc) = encoding_rs::Encoding::for_label(label.as_bytes()) {
+        return Ok(enc);
+    }
+    // Handle common aliases not in the Encoding Standard
+    let alias = match label.to_ascii_lowercase().as_str() {
+        "latin-1" | "latin1" => Some("iso-8859-1"),
+        "ascii" | "us-ascii" => Some("windows-1252"),
+        _ => None,
+    };
+    if let Some(alias_label) = alias {
+        if let Some(enc) = encoding_rs::Encoding::for_label(alias_label.as_bytes()) {
+            return Ok(enc);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("Unsupported encoding: {}", label),
+    ))
+}
+
+/// Check if an encoding label is valid/supported.
+pub fn is_valid_encoding(label: &str) -> bool {
+    if label.eq_ignore_ascii_case("utf-8") {
+        return true;
+    }
+    resolve_encoding(label).is_ok()
+}
+
+/// Encode a string into bytes using the specified encoding.
+fn encode_string(content: &str, encoding: &str) -> io::Result<Vec<u8>> {
+    if encoding.eq_ignore_ascii_case("utf-8") {
+        return Ok(content.as_bytes().to_vec());
+    }
+    let enc = resolve_encoding(encoding)?;
+    let (encoded, _, had_errors) = enc.encode(content);
+    if had_errors {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Failed to encode content as {}", encoding),
+        ));
+    }
+    Ok(encoded.into_owned())
+}
+
+/// Check if a path is a symbolic link.
+pub fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+/// Resolve symlink target to an absolute path.
+/// If the symlink target is relative, resolves it against the symlink's parent directory.
+fn resolve_symlink(path: &Path) -> io::Result<PathBuf> {
+    let target = std::fs::read_link(path)?;
+    if target.is_absolute() {
+        Ok(target)
+    } else {
+        let parent = path.parent().unwrap_or(Path::new("."));
+        Ok(parent.join(target))
+    }
+}
+
 /// Write file content atomically using a temp file + rename.
 /// If `temp_suffix` is provided, uses `path.<suffix>` as the temp file name.
 /// Otherwise uses a NamedTempFile in the same directory.
+/// If `no_dereference` is true and path is a symlink, writes to the symlink's
+/// target instead of replacing the symlink.
 pub fn write_file(path: &Path, content: &str, temp_suffix: Option<&str>) -> io::Result<()> {
-    let dir = path.parent().unwrap_or(Path::new("."));
+    write_bytes_impl(path, content.as_bytes(), temp_suffix, false)
+}
+
+/// Write file with optional symlink-aware behavior.
+pub fn write_file_no_deref(
+    path: &Path,
+    content: &str,
+    temp_suffix: Option<&str>,
+    no_dereference: bool,
+) -> io::Result<()> {
+    let bytes = content.as_bytes();
+    write_bytes_impl(path, bytes, temp_suffix, no_dereference)
+}
+
+/// Write file with encoding and symlink support.
+pub fn write_file_encoded(
+    path: &Path,
+    content: &str,
+    temp_suffix: Option<&str>,
+    no_dereference: bool,
+    encoding: &str,
+) -> io::Result<()> {
+    let bytes = encode_string(content, encoding)?;
+    write_bytes_impl(path, &bytes, temp_suffix, no_dereference)
+}
+
+fn write_bytes_impl(
+    path: &Path,
+    bytes: &[u8],
+    temp_suffix: Option<&str>,
+    no_dereference: bool,
+) -> io::Result<()> {
+    let write_path = if no_dereference && is_symlink(path) {
+        resolve_symlink(path)?
+    } else {
+        path.to_path_buf()
+    };
+    let dir = write_path.parent().unwrap_or(Path::new("."));
 
     if let Some(suffix) = temp_suffix {
         // Use explicit temp file name: file.py.tmp (append suffix, not replace extension)
-        let mut temp_name = path.as_os_str().to_os_string();
+        let mut temp_name = write_path.as_os_str().to_os_string();
         temp_name.push(".");
         temp_name.push(suffix);
         let temp_path = std::path::PathBuf::from(temp_name);
         let mut file = File::create(&temp_path)?;
-        file.write_all(content.as_bytes())?;
+        file.write_all(bytes)?;
         file.sync_all()?;
-        std::fs::rename(&temp_path, path)?;
+        std::fs::rename(&temp_path, &write_path)?;
     } else {
         // Use tempfile crate for safe atomic write
         let mut tmp = NamedTempFile::new_in(dir)?;
-        tmp.write_all(content.as_bytes())?;
+        tmp.write_all(bytes)?;
         tmp.as_file().sync_all()?;
-        tmp.persist(path).map_err(|e| e.error)?;
+        tmp.persist(&write_path).map_err(|e| e.error)?;
     }
 
     Ok(())
@@ -63,6 +188,22 @@ pub fn create_backup(path: &Path, extension: &str) -> io::Result<()> {
     backup_path.push(extension);
     std::fs::copy(path, PathBuf::from(backup_path))?;
     Ok(())
+}
+
+/// Normalize line endings in content.
+/// - "preserve": return unchanged
+/// - "lf": convert all line endings to \n
+/// - "crlf": convert all line endings to \r\n
+pub fn normalize_eol(content: &str, eol: &str) -> String {
+    match eol {
+        "lf" => content.replace("\r\n", "\n").replace('\r', "\n"),
+        "crlf" => {
+            // First normalize to LF, then convert to CRLF
+            let lf = content.replace("\r\n", "\n").replace('\r', "\n");
+            lf.replace('\n', "\r\n")
+        }
+        _ => content.to_string(), // "preserve" or any other value
+    }
 }
 
 /// Function to detect if a file has UTF-8 BOM
@@ -95,10 +236,11 @@ pub fn detect_protected_lines(content: &str) -> Vec<usize> {
         }
 
         // PEP 263 encoding pragma: first or second non-blank line
-        if trimmed.starts_with('#') && (trimmed.contains("coding:") || trimmed.contains("coding=")) {
-            if !protected.contains(&i) {
-                protected.push(i);
-            }
+        if trimmed.starts_with('#')
+            && (trimmed.contains("coding:") || trimmed.contains("coding="))
+            && !protected.contains(&i)
+        {
+            protected.push(i);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,39 @@ use toggle::core;
 use toggle::exit_codes::{ExitCode, UsageError};
 use toggle::io;
 
+/// Bundled options passed through the toggle pipeline.
+struct ToggleOptions<'a> {
+    force: &'a Option<String>,
+    mode: &'a str,
+    temp_suffix: Option<&'a str>,
+    dry_run: bool,
+    backup: Option<&'a str>,
+    config: Option<&'a ToggleConfig>,
+    verbose: bool,
+    eol: &'a str,
+    no_dereference: bool,
+    encoding: &'a str,
+    json: bool,
+}
+
+/// Result of processing a single toggle operation.
+struct ProcessResult {
+    action: String,
+    lines_changed: usize,
+}
+
+/// JSON output entry for --json mode.
+#[derive(serde::Serialize)]
+struct ToggleResult {
+    file: String,
+    action: String,
+    lines_changed: usize,
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    dry_run: bool,
+}
+
 fn main() {
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
@@ -26,10 +59,16 @@ fn main() {
     };
 
     if let Err(e) = &result {
-        eprintln!("Error: {:#}", e);
+        if !cli.json {
+            eprintln!("Error: {:#}", e);
+        }
     }
 
-    let exit_val = if cli.posix_exit { code.posix() } else { code.code() };
+    let exit_val = if cli.posix_exit {
+        code.posix()
+    } else {
+        code.code()
+    };
     std::process::exit(exit_val);
 }
 
@@ -77,20 +116,97 @@ fn run(cli: &Cli) -> Result<()> {
             .map(String::from)
     };
 
+    // Validate --encoding value
+    if !io::is_valid_encoding(&cli.encoding) {
+        return Err(UsageError(format!("Unsupported encoding: '{}'", cli.encoding)).into());
+    }
+
+    // Validate --eol value
+    match cli.eol.as_str() {
+        "preserve" | "lf" | "crlf" => {}
+        other => {
+            return Err(UsageError(format!(
+                "Invalid --eol value '{}': must be preserve, lf, or crlf",
+                other
+            ))
+            .into());
+        }
+    }
+
+    let opts = ToggleOptions {
+        force: &effective_force,
+        mode: &effective_mode,
+        temp_suffix: cli.temp_suffix.as_deref(),
+        dry_run: cli.dry_run,
+        backup: cli.backup.as_deref(),
+        config: config.as_ref(),
+        verbose: cli.verbose && !cli.json, // suppress verbose in JSON mode
+        eol: &cli.eol,
+        no_dereference: cli.no_dereference,
+        encoding: &cli.encoding,
+        json: cli.json,
+    };
+
+    if cli.json {
+        run_json(cli, &opts)
+    } else {
+        run_normal(cli, &opts)
+    }
+}
+
+fn run_normal(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
     for path in &cli.paths {
-        process_path(path, cli, config.as_ref(), &effective_mode, &effective_force)
+        process_path(path, cli, opts)
             .with_context(|| format!("Failed to process {}", path.display()))?;
     }
     Ok(())
 }
 
-fn process_path(
-    path: &Path,
-    cli: &Cli,
-    config: Option<&ToggleConfig>,
-    effective_mode: &str,
-    effective_force: &Option<String>,
-) -> Result<()> {
+fn run_json(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
+    let mut results: Vec<ToggleResult> = Vec::new();
+    let mut had_error = false;
+
+    for path in &cli.paths {
+        match process_path(path, cli, opts) {
+            Ok(proc_results) => {
+                for pr in proc_results {
+                    results.push(ToggleResult {
+                        file: path.display().to_string(),
+                        action: pr.action,
+                        lines_changed: pr.lines_changed,
+                        success: true,
+                        error: None,
+                        dry_run: opts.dry_run,
+                    });
+                }
+            }
+            Err(e) => {
+                had_error = true;
+                results.push(ToggleResult {
+                    file: path.display().to_string(),
+                    action: String::new(),
+                    lines_changed: 0,
+                    success: false,
+                    error: Some(format!("{:#}", e)),
+                    dry_run: opts.dry_run,
+                });
+            }
+        }
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string(&results).expect("Failed to serialize JSON")
+    );
+
+    if had_error {
+        // Return a generic error so main() sets a non-zero exit code
+        anyhow::bail!("One or more files failed to process");
+    }
+    Ok(())
+}
+
+fn process_path(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<ProcessResult>> {
     // --strict-ext: reject non-.py files
     if cli.strict_ext {
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -103,105 +219,99 @@ fn process_path(
         }
     }
 
-    if cli.verbose {
+    if opts.verbose {
         eprintln!("Processing {}:", path.display());
     }
 
+    let mut results = Vec::new();
+
     if let Some(line_range) = &cli.line {
-        if cli.verbose {
+        if opts.verbose {
             eprintln!("  Line range: {}", line_range);
         }
-        toggle_line_range(
-            path,
-            line_range,
-            effective_force,
-            effective_mode,
-            cli.temp_suffix.as_deref(),
-            cli.dry_run,
-            cli.backup.as_deref(),
-            config,
-        )?;
+        let pr = toggle_line_range(path, line_range, opts)?;
+        results.push(pr);
     }
 
     for section in &cli.sections {
-        if cli.verbose {
+        if opts.verbose {
             eprintln!("  Section: {}", section);
         }
-        toggle_section(
-            path,
-            section,
-            effective_force,
-            effective_mode,
-            cli.verbose,
-            cli.temp_suffix.as_deref(),
-            cli.dry_run,
-            cli.backup.as_deref(),
-            config,
-        )?;
+        let pr = toggle_section(path, section, opts)?;
+        results.push(pr);
     }
 
-    Ok(())
+    Ok(results)
 }
 
-fn toggle_line_range(
-    path: &Path,
-    line_range: &str,
-    force: &Option<String>,
-    mode: &str,
-    temp_suffix: Option<&str>,
-    dry_run: bool,
-    backup: Option<&str>,
-    config: Option<&ToggleConfig>,
-) -> Result<()> {
-    let comment_style = core::get_comment_style(path, mode, config)?;
+/// Count the number of lines that differ between two strings.
+fn count_changed_lines(original: &str, modified: &str) -> usize {
+    let orig_lines: Vec<&str> = original.lines().collect();
+    let mod_lines: Vec<&str> = modified.lines().collect();
+    let max_len = orig_lines.len().max(mod_lines.len());
+    let mut changed = 0;
+    for i in 0..max_len {
+        let a = orig_lines.get(i).copied().unwrap_or("");
+        let b = mod_lines.get(i).copied().unwrap_or("");
+        if a != b {
+            changed += 1;
+        }
+    }
+    changed
+}
+
+fn toggle_line_range(path: &Path, line_range: &str, opts: &ToggleOptions) -> Result<ProcessResult> {
+    let comment_style = core::get_comment_style(path, opts.mode, opts.config)?;
     let (start_line, end_line) = core::parse_line_range(line_range)?;
-    let content = io::read_file(path)?;
+    let content = io::read_file_encoded(path, opts.encoding)?;
 
     let line_count = content.lines().count();
     if start_line > line_count {
         return Err(UsageError(format!(
             "Start line {} is out of range (file has {} lines)",
-            start_line,
-            line_count
+            start_line, line_count
         ))
         .into());
     }
 
     let range = core::LineRange::new(start_line, end_line);
-    let force_mode = force.as_deref();
-    let result = core::toggle_comments_with_marker(
+    let force_mode = opts.force.as_deref();
+    let toggled = core::toggle_comments_with_marker(
         &content,
         &[range],
         force_mode,
         &comment_style.single_line,
     );
+    let result = io::normalize_eol(&toggled, opts.eol);
+    let lines_changed = count_changed_lines(&content, &result);
 
-    if dry_run {
-        io::print_diff(path, &content, &result);
+    if opts.dry_run {
+        if !opts.json {
+            io::print_diff(path, &content, &result);
+        }
     } else {
-        if let Some(ext) = backup {
+        if let Some(ext) = opts.backup {
             io::create_backup(path, ext)?;
         }
-        io::write_file(path, &result, temp_suffix)?;
+        io::write_file_encoded(
+            path,
+            &result,
+            opts.temp_suffix,
+            opts.no_dereference,
+            opts.encoding,
+        )?;
     }
 
-    Ok(())
+    Ok(ProcessResult {
+        action: "toggle_line_range".to_string(),
+        lines_changed,
+    })
 }
 
-fn toggle_section(
-    path: &Path,
-    section_id: &str,
-    force: &Option<String>,
-    mode: &str,
-    verbose: bool,
-    temp_suffix: Option<&str>,
-    dry_run: bool,
-    backup: Option<&str>,
-    config: Option<&ToggleConfig>,
-) -> Result<()> {
-    let comment_style = core::get_comment_style(path, mode, config)?;
+fn toggle_section(path: &Path, section_id: &str, opts: &ToggleOptions) -> Result<ProcessResult> {
+    let comment_style = core::get_comment_style(path, opts.mode, opts.config)?;
 
-    if verbose {
+    if opts.verbose {
         eprintln!("  Looking for section with ID={}", section_id);
         eprintln!(
             "  Using comment style: {} for single-line comments",
@@ -209,34 +319,50 @@ fn toggle_section(
         );
     }
 
-    let original_content = io::read_file(path)?;
+    let original_content = io::read_file_encoded(path, opts.encoding)?;
     let mut lines: Vec<String> = original_content.lines().map(String::from).collect();
 
-    if verbose {
+    if opts.verbose {
         eprintln!("  File has {} lines", lines.len());
     }
 
-    let modified = core::find_and_toggle_section(&mut lines, section_id, force, &comment_style)?;
+    let modified =
+        core::find_and_toggle_section(&mut lines, section_id, opts.force, &comment_style)?;
+
+    let mut lines_changed = 0;
 
     if modified {
-        if verbose {
+        if opts.verbose {
             eprintln!("  File modified, writing changes back");
         }
-        let mut content = lines.join("\n");
+        let mut joined = lines.join("\n");
         if original_content.ends_with('\n') {
-            content.push('\n');
+            joined.push('\n');
         }
-        if dry_run {
-            io::print_diff(path, &original_content, &content);
+        let content = io::normalize_eol(&joined, opts.eol);
+        lines_changed = count_changed_lines(&original_content, &content);
+        if opts.dry_run {
+            if !opts.json {
+                io::print_diff(path, &original_content, &content);
+            }
         } else {
-            if let Some(ext) = backup {
+            if let Some(ext) = opts.backup {
                 io::create_backup(path, ext)?;
             }
-            io::write_file(path, &content, temp_suffix)?;
+            io::write_file_encoded(
+                path,
+                &content,
+                opts.temp_suffix,
+                opts.no_dereference,
+                opts.encoding,
+            )?;
         }
-    } else if verbose {
+    } else if opts.verbose {
         eprintln!("  No changes made to file");
     }
 
-    Ok(())
+    Ok(ProcessResult {
+        action: "toggle_section".to_string(),
+        lines_changed,
+    })
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::Value;
 use std::fs;
 use tempfile::TempDir;
 
@@ -157,7 +158,10 @@ fn test_dry_run_shows_diff_and_does_not_modify_file() {
         .stdout(predicates::str::contains("+++"))
         .stdout(predicates::str::contains("@@"));
     let after = fs::read_to_string(&path).unwrap();
-    assert_eq!(original, after, "file should not be modified in dry-run mode");
+    assert_eq!(
+        original, after,
+        "file should not be modified in dry-run mode"
+    );
 }
 
 #[test]
@@ -196,7 +200,10 @@ fn test_backup_creates_backup_file() {
     let backup_path = path.with_file_name("test.py.bak");
     assert!(backup_path.exists(), "backup file should exist");
     let backup_content = fs::read_to_string(&backup_path).unwrap();
-    assert_eq!(backup_content, original, "backup should contain original content");
+    assert_eq!(
+        backup_content, original,
+        "backup should contain original content"
+    );
     let modified = fs::read_to_string(&path).unwrap();
     assert!(modified.contains("#"), "original file should be toggled");
 }
@@ -205,11 +212,21 @@ fn test_backup_creates_backup_file() {
 fn test_backup_with_dry_run_skips_backup() {
     let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
     cmd()
-        .args([path.to_str().unwrap(), "-l", "1:2", "--backup", ".bak", "--dry-run"])
+        .args([
+            path.to_str().unwrap(),
+            "-l",
+            "1:2",
+            "--backup",
+            ".bak",
+            "--dry-run",
+        ])
         .assert()
         .success();
     let backup_path = path.with_file_name("test.py.bak");
-    assert!(!backup_path.exists(), "backup should not be created in dry-run mode");
+    assert!(
+        !backup_path.exists(),
+        "backup should not be created in dry-run mode"
+    );
 }
 
 // ── --config ──
@@ -239,7 +256,10 @@ single_line_delimiter = ";;"
         .assert()
         .success();
     let result = fs::read_to_string(&file_path).unwrap();
-    assert!(result.contains(";;"), "should use custom delimiter from config");
+    assert!(
+        result.contains(";;"),
+        "should use custom delimiter from config"
+    );
 }
 
 #[test]
@@ -269,7 +289,10 @@ force_state = "on"
         .assert()
         .success();
     let result = fs::read_to_string(&file_path).unwrap();
-    assert!(!result.contains("#"), "CLI --force off should override config force_state=on");
+    assert!(
+        !result.contains("#"),
+        "CLI --force off should override config force_state=on"
+    );
 }
 
 #[test]
@@ -312,7 +335,156 @@ force_state = "on"
         .assert()
         .success();
     let result = fs::read_to_string(&file_path).unwrap();
-    assert!(result.contains("# hello"), "config force_state=on should comment the line");
+    assert!(
+        result.contains("# hello"),
+        "config force_state=on should comment the line"
+    );
+}
+
+// ── --eol ──
+
+#[test]
+fn test_eol_lf_normalizes_crlf() {
+    let (_dir, path) = setup_temp_file("line1\r\nline2\r\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "--eol", "lf"])
+        .assert()
+        .success();
+    let result = fs::read(&path).unwrap();
+    assert!(
+        !result.windows(2).any(|w| w == b"\r\n"),
+        "should have no CRLF after --eol lf"
+    );
+}
+
+#[test]
+fn test_eol_crlf_normalizes_lf() {
+    let (_dir, path) = setup_temp_file("line1\nline2\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "--eol", "crlf"])
+        .assert()
+        .success();
+    let result = fs::read(&path).unwrap();
+    let content = String::from_utf8(result).unwrap();
+    assert!(
+        content.contains("\r\n"),
+        "should have CRLF after --eol crlf"
+    );
+}
+
+#[test]
+fn test_eol_preserve_keeps_original() {
+    let original = "line1\nline2\n";
+    let (_dir, path) = setup_temp_file(original, "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "--eol", "preserve"])
+        .assert()
+        .success();
+    let result = fs::read(&path).unwrap();
+    // Verify no \r was introduced
+    assert!(!result.contains(&b'\r'), "preserve should not introduce CR");
+}
+
+// ── --no-dereference ──
+
+#[cfg(unix)]
+#[test]
+fn test_no_dereference_preserves_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("target.py");
+    fs::write(&target, "hello\nworld\n").unwrap();
+    let link = dir.path().join("link.py");
+    symlink(&target, &link).unwrap();
+
+    cmd()
+        .args([link.to_str().unwrap(), "-l", "1:2", "-N"])
+        .assert()
+        .success();
+
+    // Symlink should still be a symlink
+    assert!(
+        link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "symlink should be preserved with -N"
+    );
+    // Target file should be modified
+    let result = fs::read_to_string(&target).unwrap();
+    assert!(result.contains("#"), "target should be toggled");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_default_replaces_symlink() {
+    use std::os::unix::fs::symlink;
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("target.py");
+    fs::write(&target, "hello\nworld\n").unwrap();
+    let link = dir.path().join("link.py");
+    symlink(&target, &link).unwrap();
+
+    cmd()
+        .args([link.to_str().unwrap(), "-l", "1:2"])
+        .assert()
+        .success();
+
+    // Without -N, the symlink gets replaced by the atomic rename
+    assert!(
+        !link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "without -N, symlink should be replaced by a regular file"
+    );
+}
+
+#[test]
+fn test_eol_invalid_value_errors() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "--eol", "foo"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Invalid --eol value"));
+}
+
+// ── --encoding ──
+
+#[test]
+fn test_encoding_latin1_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test.py");
+    // "café\n" in Latin-1
+    fs::write(&path, &[0x63, 0x61, 0x66, 0xe9, 0x0a]).unwrap();
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "-e", "latin-1"])
+        .assert()
+        .success();
+    let bytes = fs::read(&path).unwrap();
+    // Should have comment marker "# " (0x23 0x20) before "café"
+    assert!(
+        bytes.windows(2).any(|w| w == [0x23, 0x20]),
+        "should have # comment marker"
+    );
+    // Should still contain the é character (0xe9) in Latin-1
+    assert!(bytes.contains(&0xe9), "should preserve Latin-1 encoding");
+}
+
+#[test]
+fn test_encoding_default_utf8() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(result.contains("#"), "default UTF-8 should work as before");
+}
+
+#[test]
+fn test_encoding_invalid_errors() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "-e", "bogus-codec"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("Unsupported encoding"));
 }
 
 #[test]
@@ -345,4 +517,89 @@ single_line_delimiter = "%%"
         result.contains("%%"),
         "global single_line_delimiter should override default when no language-specific config"
     );
+}
+
+// ── --json ──
+
+#[test]
+fn test_json_output_valid_json() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
+    let output = cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert!(json.is_array(), "JSON output should be an array");
+}
+
+#[test]
+fn test_json_output_contains_fields() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
+    let output = cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Vec<Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json.len(), 1);
+    let entry = &json[0];
+    assert!(entry["file"].as_str().unwrap().contains("test.py"));
+    assert_eq!(entry["action"], "toggle_line_range");
+    assert!(entry["lines_changed"].as_u64().unwrap() > 0);
+    assert_eq!(entry["success"], true);
+    assert!(entry.get("error").is_none() || entry["error"].is_null());
+    assert_eq!(entry["dry_run"], false);
+}
+
+#[test]
+fn test_json_output_error_case() {
+    let output = cmd()
+        .args([
+            "/tmp/nonexistent_toggle_json_test.py",
+            "-l",
+            "1:1",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let json: Vec<Value> =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON even on error");
+    assert_eq!(json.len(), 1);
+    assert_eq!(json[0]["success"], false);
+    assert!(json[0]["error"].as_str().unwrap().len() > 0);
+}
+
+#[test]
+fn test_json_suppresses_verbose() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    let output = cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "--json", "-v"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        output.stderr.is_empty(),
+        "verbose output should be suppressed in JSON mode"
+    );
+    // stdout should still be valid JSON
+    let _: Vec<Value> = serde_json::from_slice(&output.stdout).unwrap();
+}
+
+#[test]
+fn test_json_with_dry_run() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
+    let output = cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--json", "--dry-run"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    // stdout should be only JSON, no diff output mixed in
+    let json: Vec<Value> = serde_json::from_slice(&output.stdout)
+        .expect("stdout should be pure JSON with no diff mixed in");
+    assert_eq!(json[0]["dry_run"], true);
+    // File should not be modified
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, "hello\nworld\n");
 }

--- a/tests/unit/config_tests.rs
+++ b/tests/unit/config_tests.rs
@@ -22,7 +22,11 @@ single_line_delimiter = "//"
 
     let langs = config.language.unwrap();
     assert_eq!(
-        langs.get("python").unwrap().single_line_delimiter.as_deref(),
+        langs
+            .get("python")
+            .unwrap()
+            .single_line_delimiter
+            .as_deref(),
         Some("#")
     );
     assert_eq!(

--- a/tests/unit/io_tests.rs
+++ b/tests/unit/io_tests.rs
@@ -1,4 +1,4 @@
-use toggle::io::detect_protected_lines;
+use toggle::io::{detect_protected_lines, is_symlink, normalize_eol, read_file_encoded};
 
 #[test]
 fn test_detect_shebang() {
@@ -42,4 +42,93 @@ fn test_detect_skips_blank_leading_lines() {
     let content = "\n\n#!/usr/bin/env python3\nprint('hello')";
     let protected = detect_protected_lines(content);
     assert_eq!(protected, vec![2]);
+}
+
+// ── normalize_eol ──
+
+#[test]
+fn test_normalize_eol_preserve() {
+    let content = "line1\r\nline2\nline3\r\n";
+    assert_eq!(normalize_eol(content, "preserve"), content);
+}
+
+#[test]
+fn test_normalize_eol_lf_converts_crlf() {
+    let content = "line1\r\nline2\r\nline3\r\n";
+    assert_eq!(normalize_eol(content, "lf"), "line1\nline2\nline3\n");
+}
+
+#[test]
+fn test_normalize_eol_lf_handles_bare_cr() {
+    let content = "line1\rline2\n";
+    assert_eq!(normalize_eol(content, "lf"), "line1\nline2\n");
+}
+
+#[test]
+fn test_normalize_eol_crlf_converts_lf() {
+    let content = "line1\nline2\nline3\n";
+    assert_eq!(
+        normalize_eol(content, "crlf"),
+        "line1\r\nline2\r\nline3\r\n"
+    );
+}
+
+#[test]
+fn test_normalize_eol_crlf_no_double_convert() {
+    // Content already has CRLF — should not double up
+    let content = "line1\r\nline2\r\n";
+    assert_eq!(normalize_eol(content, "crlf"), "line1\r\nline2\r\n");
+}
+
+// ── is_symlink ──
+
+#[cfg(unix)]
+#[test]
+fn test_is_symlink_true() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::TempDir::new().unwrap();
+    let target = dir.path().join("target.py");
+    std::fs::write(&target, "hello").unwrap();
+    let link = dir.path().join("link.py");
+    symlink(&target, &link).unwrap();
+    assert!(is_symlink(&link));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_is_symlink_false() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let file = dir.path().join("regular.py");
+    std::fs::write(&file, "hello").unwrap();
+    assert!(!is_symlink(&file));
+}
+
+// ── read_file_encoded ──
+
+#[test]
+fn test_read_file_encoded_utf8() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("test.py");
+    std::fs::write(&path, "hello world").unwrap();
+    let content = read_file_encoded(&path, "utf-8").unwrap();
+    assert_eq!(content, "hello world");
+}
+
+#[test]
+fn test_read_file_encoded_latin1() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("test.py");
+    // "café" in Latin-1: 63 61 66 e9
+    std::fs::write(&path, &[0x63, 0x61, 0x66, 0xe9]).unwrap();
+    let content = read_file_encoded(&path, "latin-1").unwrap();
+    assert_eq!(content, "caf\u{e9}");
+}
+
+#[test]
+fn test_read_file_encoded_unsupported() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("test.py");
+    std::fs::write(&path, "hello").unwrap();
+    let result = read_file_encoded(&path, "bogus-codec");
+    assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary
This PR adds several major features to the toggle CLI: JSON output mode for machine-readable results, support for multiple file encodings, line ending normalization, and proper symlink handling. It also refactors the main processing pipeline to use a unified options struct.

## Key Changes

### JSON Output (`--json` flag)
- Added `--json` flag to output results as JSON array instead of human-readable text
- Introduced `ToggleResult` struct for JSON serialization with fields: `file`, `action`, `lines_changed`, `success`, `error`, `dry_run`
- Verbose output is automatically suppressed in JSON mode to keep stdout clean
- Error messages are captured in JSON output while still setting non-zero exit codes

### Encoding Support (`--encoding` / `-e` flag)
- Added `--encoding` flag to read/write files in non-UTF-8 encodings
- Supports any encoding recognized by the Encoding Standard (UTF-8, Latin-1, ISO-8859-1, Windows-1252, ASCII, etc.)
- Includes common aliases like "latin-1" that map to standard encoding names
- Added `read_file_encoded()` and `write_file_encoded()` functions with proper error handling
- Validates encoding at startup with `is_valid_encoding()` check

### Line Ending Normalization (`--eol` flag)
- Added `--eol` flag with three modes: `preserve` (default), `lf`, `crlf`
- `lf` mode converts all line endings to Unix-style `\n`
- `crlf` mode converts all line endings to Windows-style `\r\n`
- `preserve` mode keeps original line endings unchanged
- Normalization applied after toggling comments but before writing

### Symlink Handling (`--no-dereference` / `-N` flag)
- Added `--no-dereference` flag to preserve symlinks instead of replacing them
- When enabled, writes to the symlink's target file instead of the symlink itself
- Default behavior (without flag) replaces symlinks with regular files via atomic rename
- Includes symlink detection and target resolution utilities

### Code Refactoring
- Introduced `ToggleOptions` struct to bundle all processing options, reducing parameter passing
- Split `run()` into `run_normal()` and `run_json()` for cleaner separation of concerns
- Modified `process_path()` to return `Vec<ProcessResult>` instead of `()` for result tracking
- Added `ProcessResult` struct to track action type and lines changed per operation
- Added `count_changed_lines()` utility to calculate diff statistics

### Testing
- Added comprehensive integration tests for `--json` mode (valid JSON, field presence, error handling, verbose suppression)
- Added tests for `--eol` mode (LF/CRLF conversion, preservation)
- Added tests for `--encoding` (Latin-1 roundtrip, UTF-8 default, invalid encoding errors)
- Added tests for `--no-dereference` (symlink preservation on Unix)
- Added unit tests for `normalize_eol()`, `is_symlink()`, and `read_file_encoded()`

### Dependencies
- Added `serde_json` for JSON serialization
- Added `encoding_rs` for multi-encoding support

## Implementation Details
- The `ToggleOptions` struct uses references to avoid cloning large data structures
- Encoding validation happens early in `run()` to fail fast on invalid values
- EOL normalization is applied consistently after all comment toggling operations
- Symlink handling respects the atomic write semantics (temp file + rename)
- JSON mode suppresses all stderr output except the final JSON array on stdout

https://claude.ai/code/session_01Bv93D1K5FhZ6kjABWb1p8H