### PR TITLE
Replace cargo-husky with lefthook for pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Tests
+        run: cargo test

--- a/Justfile
+++ b/Justfile
@@ -129,17 +129,16 @@ alias rr := run-release
 
 alias b := build
 
-# Set up pre-commit hooks
+# Set up pre-commit hooks (install lefthook hooks into .git)
 [group('pre-commit')]
 @pre-commit-setup:
-    cargo install cargo-husky
-    cargo husky install
+    lefthook install
+    echo "{{GREEN}}Pre-commit hooks installed via lefthook.{{NC}}"
 
-
-# Run all pre-commit Hooks
+# Run all pre-commit checks manually
 [group('pre-commit')]
 @pre-commit-run:
-    cargo husky run --all
+    lefthook run pre-commit
 
 alias pc := pre-commit-run
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt:
+      run: cargo fmt --all -- --check
+    clippy:
+      run: cargo clippy -- -D warnings
+
+pre-push:
+  commands:
+    test:
+      run: cargo test


### PR DESCRIPTION
## Summary
This PR replaces the cargo-husky pre-commit hook framework with lefthook, a language-agnostic git hooks manager. This change improves the development workflow by using a more flexible and widely-adopted tool.

## Key Changes
- **Added CI workflow** (`.github/workflows/ci.yml`): Automated checks on push to main and pull requests, including format validation, clippy linting, and test execution
- **Added lefthook configuration** (`lefthook.yml`): Defines pre-commit and pre-push hooks that run cargo fmt, clippy, and tests
- **Updated Justfile**: 
  - Replaced `cargo husky install` with `lefthook install` in the `pre-commit-setup` recipe
  - Updated `pre-commit-run` recipe to use `lefthook run pre-commit` instead of `cargo husky run --all`
  - Improved documentation with clearer recipe descriptions

## Benefits
- **Better tooling**: Lefthook is language-agnostic and more actively maintained than cargo-husky
- **Consistent checks**: Pre-commit hooks now match the CI pipeline checks exactly
- **Improved developer experience**: Parallel execution of pre-commit checks and clearer hook management

https://claude.ai/code/session_01NtEUbsDvhomb1qPCET8gmB