### PR TITLE
Add multi-line comments, interactive mode, and repeatable line ranges

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,9 +10,9 @@ pub struct Cli {
     #[arg(required = true)]
     pub paths: Vec<PathBuf>,
 
-    /// Line range in format <start_line>:<end_line> or <start_line>:+<count>
-    #[arg(short = 'l', long = "line")]
-    pub line: Option<String>,
+    /// Line range in format <start_line>:<end_line> or <start_line>:+<count> (repeatable)
+    #[arg(short = 'l', long = "line", action = clap::ArgAction::Append)]
+    pub lines: Vec<String>,
 
     /// Section ID to toggle
     #[arg(short = 'S', long = "section", action = clap::ArgAction::Append)]
@@ -58,6 +58,14 @@ pub struct Cli {
     #[arg(short = 'x', long = "posix-exit")]
     pub posix_exit: bool,
 
+    /// Override comment style: SINGLE [MULTI_START MULTI_END]
+    #[arg(long = "comment-style", num_args = 1..=3, value_names = ["SINGLE", "MULTI_START", "MULTI_END"])]
+    pub comment_style: Vec<String>,
+
+    /// Prompt before modifying each file
+    #[arg(short = 'i', long = "interactive")]
+    pub interactive: bool,
+
     /// Show diff of changes without writing files
     #[arg(long = "dry-run")]
     pub dry_run: bool,
@@ -65,6 +73,10 @@ pub struct Cli {
     /// Create backup with given extension before modifying (e.g. --backup .bak)
     #[arg(long = "backup")]
     pub backup: Option<String>,
+
+    /// Extend the last --line range to the end of file
+    #[arg(long = "to-end")]
+    pub to_end: bool,
 
     /// Path to .toggleConfig TOML file
     #[arg(long = "config")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,4 +46,21 @@ impl ToggleConfig {
             .and_then(|langs| langs.get(lang))
             .and_then(|lc| lc.single_line_delimiter.as_deref())
     }
+
+    /// Get multi-line comment delimiters for a given language name.
+    /// Returns None if no language-specific multi-line override is configured.
+    pub fn get_language_multi_line_delimiters(&self, lang: &str) -> Option<(&str, &str)> {
+        self.language
+            .as_ref()
+            .and_then(|langs| langs.get(lang))
+            .and_then(|lc| {
+                match (
+                    lc.multi_line_delimiter_start.as_deref(),
+                    lc.multi_line_delimiter_end.as_deref(),
+                ) {
+                    (Some(start), Some(end)) => Some((start, end)),
+                    _ => None,
+                }
+            })
+    }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -25,6 +25,8 @@ impl LineRange {
 #[derive(Debug, Clone)]
 pub struct CommentStyle {
     pub single_line: String,
+    pub multi_line_start: Option<String>,
+    pub multi_line_end: Option<String>,
 }
 
 /// Parse a line range specification.
@@ -210,6 +212,86 @@ fn toggle_comments_inner(
     result
 }
 
+/// Toggle comments using multi-line/block comment delimiters.
+/// For each merged range, wraps the content in start/end delimiters (commenting)
+/// or strips them (uncommenting). Force mode works the same as single-line.
+pub fn toggle_comments_multi(
+    content: &str,
+    ranges: &[LineRange],
+    force_mode: Option<&str>,
+    start_delim: &str,
+    end_delim: &str,
+) -> String {
+    let mut lines: Vec<String> = content.lines().map(String::from).collect();
+    let merged = merge_ranges(ranges);
+
+    for range in &merged {
+        let start = range.start.saturating_sub(1);
+        let end = range.end.min(lines.len());
+
+        if start >= lines.len() || start >= end {
+            continue;
+        }
+
+        // Detect if the range is already block-commented:
+        // first non-blank line starts with start_delim, last non-blank line ends with end_delim
+        let first_trimmed = lines[start].trim_start();
+        let last_trimmed = lines[end - 1].trim_end();
+        let is_commented =
+            first_trimmed.starts_with(start_delim) && last_trimmed.ends_with(end_delim);
+
+        let should_comment = match force_mode {
+            Some("on") => true,
+            Some("off") => false,
+            _ => !is_commented,
+        };
+
+        if should_comment && !is_commented {
+            // Wrap: prepend start_delim to first line, append end_delim to last line
+            let first_line = &lines[start];
+            let leading_ws: String = first_line
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .collect();
+            let rest = &first_line[leading_ws.len()..];
+            lines[start] = format!("{}{} {}", leading_ws, start_delim, rest);
+
+            let last_line = &lines[end - 1];
+            lines[end - 1] = format!("{} {}", last_line, end_delim);
+        } else if !should_comment && is_commented {
+            // Unwrap: strip start_delim from first line, strip end_delim from last line
+            let first_line = &lines[start];
+            let leading_ws: String = first_line
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .collect();
+            let rest = &first_line[leading_ws.len()..];
+            let stripped_start = if let Some(s) = rest.strip_prefix(start_delim) {
+                let s = s.strip_prefix(' ').unwrap_or(s);
+                format!("{}{}", leading_ws, s)
+            } else {
+                first_line.clone()
+            };
+            lines[start] = stripped_start;
+
+            let last_line = &lines[end - 1];
+            let stripped_end = if let Some(s) = last_line.strip_suffix(end_delim) {
+                let s = s.strip_suffix(' ').unwrap_or(s);
+                s.to_string()
+            } else {
+                last_line.clone()
+            };
+            lines[end - 1] = stripped_end;
+        }
+    }
+
+    let mut result = lines.join("\n");
+    if content.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
 /// Map file extension to language name for config lookup
 fn ext_to_language(ext: &str) -> &str {
     match ext {
@@ -254,8 +336,11 @@ pub fn get_comment_style(
         let lang = ext_to_language(extension);
         // Language-specific override
         if let Some(delimiter) = cfg.get_language_delimiter(lang) {
+            let multi = cfg.get_language_multi_line_delimiters(lang);
             return Ok(CommentStyle {
                 single_line: delimiter.to_string(),
+                multi_line_start: multi.map(|(s, _)| s.to_string()),
+                multi_line_end: multi.map(|(_, e)| e.to_string()),
             });
         }
         // Global override
@@ -264,14 +349,21 @@ pub fn get_comment_style(
             .as_ref()
             .and_then(|g| g.single_line_delimiter.as_deref())
         {
+            let global = cfg.global.as_ref();
             return Ok(CommentStyle {
                 single_line: delimiter.to_string(),
+                multi_line_start: global
+                    .and_then(|g| g.multi_line_delimiter_start.as_deref())
+                    .map(String::from),
+                multi_line_end: global
+                    .and_then(|g| g.multi_line_delimiter_end.as_deref())
+                    .map(String::from),
             });
         }
     }
 
     let mut comment_styles = HashMap::new();
-    // Hash-style comments
+    // Hash-style comments (no multi-line)
     for ext in &[
         "py", "sh", "rb", "yaml", "yml", "toml", "r", "ex", "exs", "pl", "pm",
     ] {
@@ -279,10 +371,12 @@ pub fn get_comment_style(
             *ext,
             CommentStyle {
                 single_line: "#".to_string(),
+                multi_line_start: None,
+                multi_line_end: None,
             },
         );
     }
-    // Slash-style comments
+    // Slash-style comments with /* */ multi-line
     for ext in &[
         "js", "jsx", "ts", "tsx", "rs", "java", "c", "cpp", "go", "swift", "kt", "scala", "php",
     ] {
@@ -290,18 +384,36 @@ pub fn get_comment_style(
             *ext,
             CommentStyle {
                 single_line: "//".to_string(),
+                multi_line_start: Some("/*".to_string()),
+                multi_line_end: Some("*/".to_string()),
             },
         );
     }
     // Dash-style comments
-    for ext in &["lua", "hs", "sql"] {
-        comment_styles.insert(
-            *ext,
-            CommentStyle {
-                single_line: "--".to_string(),
-            },
-        );
-    }
+    comment_styles.insert(
+        "lua",
+        CommentStyle {
+            single_line: "--".to_string(),
+            multi_line_start: Some("--[[".to_string()),
+            multi_line_end: Some("]]".to_string()),
+        },
+    );
+    comment_styles.insert(
+        "hs",
+        CommentStyle {
+            single_line: "--".to_string(),
+            multi_line_start: Some("{-".to_string()),
+            multi_line_end: Some("-}".to_string()),
+        },
+    );
+    comment_styles.insert(
+        "sql",
+        CommentStyle {
+            single_line: "--".to_string(),
+            multi_line_start: Some("/*".to_string()),
+            multi_line_end: Some("*/".to_string()),
+        },
+    );
 
     comment_styles
         .get(extension)
@@ -339,9 +451,7 @@ pub fn find_and_toggle_section(
             let section_end = match section_end {
                 Some(end) => end,
                 None => {
-                    return Err(
-                        UsageError(format!("Unclosed section ID={}", section_id)).into()
-                    );
+                    return Err(UsageError(format!("Unclosed section ID={}", section_id)).into());
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
+use std::io::IsTerminal;
 use std::path::Path;
 
 use toggle::cli::Cli;
@@ -21,6 +22,9 @@ struct ToggleOptions<'a> {
     no_dereference: bool,
     encoding: &'a str,
     json: bool,
+    to_end: bool,
+    comment_style_override: &'a [String],
+    interactive: bool,
 }
 
 /// Result of processing a single toggle operation.
@@ -121,6 +125,19 @@ fn run(cli: &Cli) -> Result<()> {
         return Err(UsageError(format!("Unsupported encoding: '{}'", cli.encoding)).into());
     }
 
+    // Validate --comment-style: must be 1 or 3 values
+    if cli.comment_style.len() == 2 {
+        return Err(UsageError(
+            "--comment-style requires 1 value (single-line) or 3 values (single-line, multi-start, multi-end)".into(),
+        )
+        .into());
+    }
+
+    // Validate --to-end requires --line
+    if cli.to_end && cli.lines.is_empty() {
+        return Err(UsageError("--to-end requires at least one --line range".into()).into());
+    }
+
     // Validate --eol value
     match cli.eol.as_str() {
         "preserve" | "lf" | "crlf" => {}
@@ -145,6 +162,9 @@ fn run(cli: &Cli) -> Result<()> {
         no_dereference: cli.no_dereference,
         encoding: &cli.encoding,
         json: cli.json,
+        to_end: cli.to_end,
+        comment_style_override: &cli.comment_style,
+        interactive: cli.interactive,
     };
 
     if cli.json {
@@ -225,11 +245,13 @@ fn process_path(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<Proc
 
     let mut results = Vec::new();
 
-    if let Some(line_range) = &cli.line {
+    if !cli.lines.is_empty() {
         if opts.verbose {
-            eprintln!("  Line range: {}", line_range);
+            for lr in &cli.lines {
+                eprintln!("  Line range: {}", lr);
+            }
         }
-        let pr = toggle_line_range(path, line_range, opts)?;
+        let pr = toggle_line_ranges(path, &cli.lines, opts)?;
         results.push(pr);
     }
 
@@ -260,55 +282,145 @@ fn count_changed_lines(original: &str, modified: &str) -> usize {
     changed
 }
 
-fn toggle_line_range(path: &Path, line_range: &str, opts: &ToggleOptions) -> Result<ProcessResult> {
-    let comment_style = core::get_comment_style(path, opts.mode, opts.config)?;
-    let (start_line, end_line) = core::parse_line_range(line_range)?;
-    let content = io::read_file_encoded(path, opts.encoding)?;
-
-    let line_count = content.lines().count();
-    if start_line > line_count {
-        return Err(UsageError(format!(
-            "Start line {} is out of range (file has {} lines)",
-            start_line, line_count
-        ))
-        .into());
-    }
-    if end_line > line_count {
-        return Err(UsageError(format!(
-            "End line {} is out of range (file has {} lines)",
-            end_line,
-            line_count
-        ))
-        .into());
-    }
-
-    let range = core::LineRange::new(start_line, end_line);
-    let force_mode = opts.force.as_deref();
-    let toggled = core::toggle_comments_with_marker(
-        &content,
-        &[range],
-        force_mode,
-        &comment_style.single_line,
-    );
-    let result = io::normalize_eol(&toggled, opts.eol);
-    let lines_changed = count_changed_lines(&content, &result);
+/// Apply changes to a file: handles dry-run, interactive prompt, backup, and write.
+/// Returns the number of lines changed.
+fn apply_changes(
+    path: &Path,
+    original: &str,
+    modified: &str,
+    opts: &ToggleOptions,
+) -> Result<usize> {
+    let lines_changed = count_changed_lines(original, modified);
 
     if opts.dry_run {
         if !opts.json {
-            io::print_diff(path, &content, &result);
+            io::print_diff(path, original, modified);
         }
-    } else {
-        if let Some(ext) = opts.backup {
-            io::create_backup(path, ext)?;
+        if opts.interactive && std::io::stdin().is_terminal() {
+            // In dry-run + interactive, just show the diff (already done above)
+            eprintln!("(dry-run mode, no changes will be written)");
         }
-        io::write_file_encoded(
-            path,
-            &result,
-            opts.temp_suffix,
-            opts.no_dereference,
-            opts.encoding,
-        )?;
+        return Ok(lines_changed);
     }
+
+    // Interactive prompt
+    if opts.interactive {
+        // Show diff preview before prompting (only on TTY to avoid polluting piped output)
+        if std::io::stdin().is_terminal() && !opts.json {
+            io::print_diff(path, original, modified);
+        }
+        eprint!("Modify {}? [y/N] ", path.display());
+        use std::io::Write;
+        std::io::stderr().flush().ok();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .map_err(|e| anyhow::anyhow!("Failed to read interactive input: {}", e))?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            if opts.verbose {
+                eprintln!("  Skipped {}", path.display());
+            }
+            return Ok(0);
+        }
+    }
+
+    if let Some(ext) = opts.backup {
+        io::create_backup(path, ext)?;
+    }
+    io::write_file_encoded(
+        path,
+        modified,
+        opts.temp_suffix,
+        opts.no_dereference,
+        opts.encoding,
+    )?;
+    Ok(lines_changed)
+}
+
+/// Resolve comment style for a file, applying --comment-style override if present.
+fn resolve_comment_style(path: &Path, opts: &ToggleOptions) -> Result<core::CommentStyle> {
+    if !opts.comment_style_override.is_empty() {
+        let single = opts.comment_style_override[0].clone();
+        let (ms, me) = if opts.comment_style_override.len() == 3 {
+            (
+                Some(opts.comment_style_override[1].clone()),
+                Some(opts.comment_style_override[2].clone()),
+            )
+        } else {
+            (None, None)
+        };
+        return Ok(core::CommentStyle {
+            single_line: single,
+            multi_line_start: ms,
+            multi_line_end: me,
+        });
+    }
+    core::get_comment_style(path, opts.mode, opts.config)
+}
+
+fn toggle_line_ranges(
+    path: &Path,
+    line_range_specs: &[String],
+    opts: &ToggleOptions,
+) -> Result<ProcessResult> {
+    let comment_style = resolve_comment_style(path, opts)?;
+    let content = io::read_file_encoded(path, opts.encoding)?;
+    let line_count = content.lines().count();
+
+    // Parse all range specs into LineRange values
+    let mut ranges = Vec::new();
+    for spec in line_range_specs {
+        let (start_line, end_line) = core::parse_line_range(spec)?;
+        if start_line > line_count {
+            return Err(UsageError(format!(
+                "Start line {} is out of range (file has {} lines)",
+                start_line, line_count
+            ))
+            .into());
+        }
+        ranges.push(core::LineRange::new(start_line, end_line));
+    }
+
+    // --to-end: extend the last range's end to the file's line count
+    if opts.to_end {
+        if let Some(last) = ranges.last_mut() {
+            last.end = line_count;
+        }
+    }
+
+    // Validate end lines against file length (after --to-end extension)
+    for range in &ranges {
+        if range.end > line_count {
+            return Err(UsageError(format!(
+                "End line {} is out of range (file has {} lines)",
+                range.end, line_count
+            ))
+            .into());
+        }
+    }
+
+    let merged = core::merge_ranges(&ranges);
+    let force_mode = opts.force.as_deref();
+    let toggled = if opts.mode == "multi" {
+        let (ms, me) = match (
+            &comment_style.multi_line_start,
+            &comment_style.multi_line_end,
+        ) {
+            (Some(s), Some(e)) => (s.as_str(), e.as_str()),
+            _ => {
+                return Err(UsageError(format!(
+                    "Multi-line comments not supported for {}",
+                    path.display()
+                ))
+                .into());
+            }
+        };
+        core::toggle_comments_multi(&content, &merged, force_mode, ms, me)
+    } else {
+        core::toggle_comments_with_marker(&content, &merged, force_mode, &comment_style.single_line)
+    };
+    let result = io::normalize_eol(&toggled, opts.eol);
+    let lines_changed = apply_changes(path, &content, &result, opts)?;
 
     Ok(ProcessResult {
         action: "toggle_line_range".to_string(),
@@ -317,7 +429,7 @@ fn toggle_line_range(path: &Path, line_range: &str, opts: &ToggleOptions) -> Res
 }
 
 fn toggle_section(path: &Path, section_id: &str, opts: &ToggleOptions) -> Result<ProcessResult> {
-    let comment_style = core::get_comment_style(path, opts.mode, opts.config)?;
+    let comment_style = resolve_comment_style(path, opts)?;
 
     if opts.verbose {
         eprintln!("  Looking for section with ID={}", section_id);
@@ -348,23 +460,7 @@ fn toggle_section(path: &Path, section_id: &str, opts: &ToggleOptions) -> Result
             joined.push('\n');
         }
         let content = io::normalize_eol(&joined, opts.eol);
-        lines_changed = count_changed_lines(&original_content, &content);
-        if opts.dry_run {
-            if !opts.json {
-                io::print_diff(path, &original_content, &content);
-            }
-        } else {
-            if let Some(ext) = opts.backup {
-                io::create_backup(path, ext)?;
-            }
-            io::write_file_encoded(
-                path,
-                &content,
-                opts.temp_suffix,
-                opts.no_dereference,
-                opts.encoding,
-            )?;
-        }
+        lines_changed = apply_changes(path, &original_content, &content, opts)?;
     } else if opts.verbose {
         eprintln!("  No changes made to file");
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,6 +15,177 @@ fn setup_temp_file(content: &str, filename: &str) -> (TempDir, std::path::PathBu
     (dir, path)
 }
 
+// ── Repeatable --line ranges (Phase 2) ──
+
+#[test]
+fn test_multiple_line_ranges_non_adjacent() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\nd\ne\nf\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "2:3", "-l", "5:6"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "a\n# b\n# c\nd\n# e\n# f\n");
+}
+
+#[test]
+fn test_multiple_line_ranges_overlapping() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\nd\ne\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:3", "-l", "2:4"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    // Lines 1-4 should all be commented (merged ranges)
+    assert_eq!(result, "# a\n# b\n# c\n# d\ne\n");
+}
+
+// ── --to-end (Phase 2) ──
+
+#[test]
+fn test_to_end_extends_to_eof() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\nd\ne\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "3", "--to-end"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "a\nb\n# c\n# d\n# e\n");
+}
+
+#[test]
+fn test_to_end_without_line_errors() {
+    let (_dir, path) = setup_temp_file("a\nb\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "--to-end"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--to-end requires"));
+}
+
+// ── Multi-line comment support (Phase 2) ──
+
+#[test]
+fn test_multi_line_mode_wraps_in_block_comment() {
+    let (_dir, path) = setup_temp_file("line1\nline2\nline3\nline4\n", "test.js");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "2:3", "-m", "multi"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(result.contains("/*"), "should contain block comment start");
+    assert!(result.contains("*/"), "should contain block comment end");
+}
+
+#[test]
+fn test_multi_line_mode_unwraps_block_comment() {
+    let (_dir, path) = setup_temp_file("line1\n/* line2\nline3 */\nline4\n", "test.js");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "2:3", "-m", "multi"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(!result.contains("/*"), "should unwrap block comment start");
+    assert!(!result.contains("*/"), "should unwrap block comment end");
+}
+
+#[test]
+fn test_multi_line_mode_unsupported_for_python() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:1", "-m", "multi"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Multi-line comments not supported",
+        ));
+}
+
+// ── --comment-style override (Phase 2) ──
+
+#[test]
+fn test_comment_style_single_override() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.txt");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--comment-style", "//"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(
+        result.contains("// hello"),
+        "should use custom // delimiter"
+    );
+}
+
+#[test]
+fn test_comment_style_with_multi_line() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\n", "test.txt");
+    cmd()
+        .args([
+            path.to_str().unwrap(),
+            "-l",
+            "1:2",
+            "-m",
+            "multi",
+            "--comment-style",
+            "//",
+            "/*",
+            "*/",
+        ])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(result.contains("/*"), "should use custom multi-line start");
+    assert!(result.contains("*/"), "should use custom multi-line end");
+}
+
+#[test]
+fn test_comment_style_two_values_errors() {
+    let (_dir, path) = setup_temp_file("hello\n", "test.py");
+    cmd()
+        .args([
+            path.to_str().unwrap(),
+            "-l",
+            "1:1",
+            "--comment-style",
+            "//",
+            "/*",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--comment-style requires"));
+}
+
+// ── --interactive (Phase 2) ──
+
+#[test]
+fn test_interactive_yes_modifies_file() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--interactive"])
+        .write_stdin("y\n")
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert!(result.contains("#"), "file should be modified on 'y'");
+}
+
+#[test]
+fn test_interactive_no_skips_modification() {
+    let (_dir, path) = setup_temp_file("hello\nworld\n", "test.py");
+    let original = fs::read_to_string(&path).unwrap();
+    cmd()
+        .args([path.to_str().unwrap(), "-l", "1:2", "--interactive"])
+        .write_stdin("n\n")
+        .assert()
+        .success();
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(
+        original, after,
+        "file should not be modified when user answers 'n'"
+    );
+}
+
 // ── Line range toggling ──
 
 #[test]

--- a/tests/unit/core_tests.rs
+++ b/tests/unit/core_tests.rs
@@ -230,6 +230,8 @@ fn test_get_comment_style_unsupported() {
 fn test_section_toggle_preserves_trailing_empty_lines() {
     let style = CommentStyle {
         single_line: "#".to_string(),
+        multi_line_start: None,
+        multi_line_end: None,
     };
     let mut lines = vec![
         "# toggle:start ID=sec1".to_string(),


### PR DESCRIPTION
## Summary
This PR implements Phase 2 features for the toggle comment tool, adding support for multi-line/block comment toggling, interactive confirmation prompts, repeatable line range arguments, and comment style overrides.

## Key Changes

### Multi-line Comment Support
- Added `toggle_comments_multi()` function to handle block comment wrapping/unwrapping with configurable delimiters
- Extended `CommentStyle` struct with `multi_line_start` and `multi_line_end` optional fields
- Updated language-specific comment style mappings to include multi-line delimiters (e.g., `/* */` for JavaScript, `--[[ ]]` for Lua)
- Added `-m multi` mode support to toggle between single-line and multi-line comments
- Validates that multi-line mode is supported for the target file type

### Repeatable Line Ranges
- Changed `--line` argument from single optional to repeatable (`Vec<String>`) using `clap::ArgAction::Append`
- Refactored `toggle_line_range()` to `toggle_line_ranges()` to handle multiple ranges
- Implemented range merging to handle overlapping/adjacent ranges correctly
- Added `--to-end` flag to extend the last line range to end-of-file

### Interactive Mode
- Added `--interactive` / `-i` flag for per-file confirmation prompts
- Shows diff preview before prompting (only on TTY to avoid polluting piped output)
- Skips file modification if user answers anything other than 'y'
- Works with both normal and dry-run modes

### Comment Style Override
- Added `--comment-style` argument accepting 1 value (single-line) or 3 values (single-line, multi-start, multi-end)
- Validates that exactly 1 or 3 values are provided (rejects 2-value input)
- Overrides file-type detection when specified
- Implemented `resolve_comment_style()` helper to apply overrides

### Code Refactoring
- Extracted `apply_changes()` function to consolidate file modification logic (dry-run, interactive, backup, write)
- Extracted `resolve_comment_style()` to centralize comment style resolution with override support
- Updated config module with `get_language_multi_line_delimiters()` method

## Testing
Added comprehensive integration tests covering:
- Multiple non-adjacent and overlapping line ranges
- `--to-end` functionality and validation
- Multi-line comment wrapping/unwrapping
- Comment style overrides (single and multi-line)
- Interactive mode with yes/no responses
- Error cases (unsupported multi-line, invalid comment-style values)

https://claude.ai/code/session_01NY7UFQvZ54UvBjVouUQCEU