### PR TITLE
Add recursive directory traversal with -R/--recursive flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,4 +81,8 @@ pub struct Cli {
     /// Path to .toggleConfig TOML file
     #[arg(long = "config")]
     pub config: Option<PathBuf>,
+
+    /// Recursively search directories for files to process
+    #[arg(short = 'R', long = "recursive")]
+    pub recursive: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::io::IsTerminal;
 use std::path::Path;
+use walkdir::WalkDir;
 
 use toggle::cli::Cli;
 use toggle::config::ToggleConfig;
@@ -25,6 +26,7 @@ struct ToggleOptions<'a> {
     to_end: bool,
     comment_style_override: &'a [String],
     interactive: bool,
+    recursive: bool,
 }
 
 /// Result of processing a single toggle operation.
@@ -165,6 +167,7 @@ fn run(cli: &Cli) -> Result<()> {
         to_end: cli.to_end,
         comment_style_override: &cli.comment_style,
         interactive: cli.interactive,
+        recursive: cli.recursive,
     };
 
     if cli.json {
@@ -227,6 +230,44 @@ fn run_json(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
 }
 
 fn process_path(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<ProcessResult>> {
+    // If path is a directory, handle recursive traversal
+    if path.is_dir() {
+        if !opts.recursive {
+            return Err(UsageError(format!(
+                "'{}' is a directory; use -R/--recursive to process directories",
+                path.display()
+            ))
+            .into());
+        }
+        let mut results = Vec::new();
+        for entry in WalkDir::new(path)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+        {
+            let file_path = entry.path();
+            // Skip files with unsupported extensions (unless --comment-style is set)
+            if opts.comment_style_override.is_empty()
+                && core::get_comment_style(file_path, opts.mode, opts.config).is_err()
+            {
+                continue;
+            }
+            match process_file(file_path, cli, opts) {
+                Ok(mut file_results) => results.append(&mut file_results),
+                Err(e) => {
+                    if opts.verbose {
+                        eprintln!("  Skipping {}: {}", file_path.display(), e);
+                    }
+                }
+            }
+        }
+        return Ok(results);
+    }
+
+    process_file(path, cli, opts)
+}
+
+fn process_file(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<ProcessResult>> {
     // --strict-ext: reject non-.py files
     if cli.strict_ext {
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -774,3 +774,140 @@ fn test_json_with_dry_run() {
     let after = fs::read_to_string(&path).unwrap();
     assert_eq!(after, "hello\nworld\n");
 }
+
+// ── -R/--recursive directory traversal ──
+
+fn setup_temp_dir_with_files(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    for (name, content) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, content).unwrap();
+    }
+    dir
+}
+
+#[test]
+fn test_recursive_toggles_all_files_in_directory() {
+    let dir = setup_temp_dir_with_files(&[
+        ("a.py", "hello\nworld\n"),
+        ("b.py", "foo\nbar\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:2", "-R"])
+        .assert()
+        .success();
+    let a = fs::read_to_string(dir.path().join("a.py")).unwrap();
+    let b = fs::read_to_string(dir.path().join("b.py")).unwrap();
+    assert!(a.contains("# hello"), "a.py should be commented");
+    assert!(b.contains("# foo"), "b.py should be commented");
+}
+
+#[test]
+fn test_recursive_traverses_subdirectories() {
+    let dir = setup_temp_dir_with_files(&[
+        ("top.py", "top\n"),
+        ("sub/nested.py", "nested\n"),
+        ("sub/deep/deep.py", "deep\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1", "-R"])
+        .assert()
+        .success();
+    assert!(fs::read_to_string(dir.path().join("top.py")).unwrap().contains("# top"));
+    assert!(fs::read_to_string(dir.path().join("sub/nested.py")).unwrap().contains("# nested"));
+    assert!(fs::read_to_string(dir.path().join("sub/deep/deep.py")).unwrap().contains("# deep"));
+}
+
+#[test]
+fn test_recursive_skips_unsupported_extensions() {
+    let dir = setup_temp_dir_with_files(&[
+        ("code.py", "hello\n"),
+        ("readme.md", "# Title\n"),
+        ("data.csv", "a,b,c\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1", "-R"])
+        .assert()
+        .success();
+    // .py should be toggled
+    assert!(fs::read_to_string(dir.path().join("code.py")).unwrap().contains("# hello"));
+    // .md and .csv should be untouched
+    assert_eq!(fs::read_to_string(dir.path().join("readme.md")).unwrap(), "# Title\n");
+    assert_eq!(fs::read_to_string(dir.path().join("data.csv")).unwrap(), "a,b,c\n");
+}
+
+#[test]
+fn test_recursive_with_section_toggle() {
+    let dir = setup_temp_dir_with_files(&[
+        ("a.py", "before\n# toggle:start ID=feat\nhello\n# toggle:end ID=feat\nafter\n"),
+        ("b.py", "start\n# toggle:start ID=feat\nworld\n# toggle:end ID=feat\nend\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-S", "feat", "-f", "on", "-R"])
+        .assert()
+        .success();
+    let a = fs::read_to_string(dir.path().join("a.py")).unwrap();
+    let b = fs::read_to_string(dir.path().join("b.py")).unwrap();
+    assert!(a.contains("# hello"), "a.py section should be commented");
+    assert!(b.contains("# world"), "b.py section should be commented");
+}
+
+#[test]
+fn test_recursive_with_multiple_languages() {
+    let dir = setup_temp_dir_with_files(&[
+        ("app.py", "print('hi')\n"),
+        ("app.js", "console.log('hi');\n"),
+        ("app.rs", "fn main() {}\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1", "-R"])
+        .assert()
+        .success();
+    assert!(fs::read_to_string(dir.path().join("app.py")).unwrap().contains("# "));
+    assert!(fs::read_to_string(dir.path().join("app.js")).unwrap().contains("// "));
+    assert!(fs::read_to_string(dir.path().join("app.rs")).unwrap().contains("// "));
+}
+
+#[test]
+fn test_directory_without_recursive_flag_errors() {
+    let dir = setup_temp_dir_with_files(&[("test.py", "hello\n")]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("use -R/--recursive"));
+}
+
+#[test]
+fn test_recursive_with_dry_run() {
+    let dir = setup_temp_dir_with_files(&[
+        ("a.py", "hello\n"),
+        ("b.py", "world\n"),
+    ]);
+    cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1", "-R", "--dry-run"])
+        .assert()
+        .success();
+    // Files should not be modified
+    assert_eq!(fs::read_to_string(dir.path().join("a.py")).unwrap(), "hello\n");
+    assert_eq!(fs::read_to_string(dir.path().join("b.py")).unwrap(), "world\n");
+}
+
+#[test]
+fn test_recursive_with_json_output() {
+    let dir = setup_temp_dir_with_files(&[
+        ("a.py", "hello\n"),
+        ("sub/b.js", "world\n"),
+    ]);
+    let output = cmd()
+        .args([dir.path().to_str().unwrap(), "-l", "1:1", "-R", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let json: Vec<Value> = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.len() >= 2, "JSON should have entries for each processed file");
+    assert!(json.iter().all(|e| e["success"] == true));
+}


### PR DESCRIPTION
## Summary
This PR adds support for recursively processing directories with the new `-R/--recursive` flag, allowing users to toggle comments across multiple files in a directory tree in a single operation.

## Key Changes
- **New CLI flag**: Added `-R/--recursive` argument to `Cli` struct to enable directory traversal
- **Directory handling**: Modified `process_path()` to detect directories and traverse them using `walkdir` crate
- **File filtering**: Automatically skips files with unsupported extensions unless `--comment-style` is explicitly set
- **Error handling**: Returns a clear error message when a directory is passed without the `-R` flag
- **Feature compatibility**: Recursive mode works seamlessly with existing features:
  - Section-based toggling (`-S` flag)
  - Dry-run mode (`--dry-run`)
  - JSON output (`--json`)
  - Multiple language support (applies correct comment syntax per file type)
  - Verbose output

## Implementation Details
- Refactored `process_path()` to handle both files and directories, delegating file processing to a new `process_file()` function
- Uses `walkdir::WalkDir` for efficient recursive directory traversal
- Gracefully skips files that cannot be processed (unsupported extensions or errors) while continuing to process other files
- Maintains backward compatibility: single file operations work exactly as before

https://claude.ai/code/session_01MGNtqfW8vnW6VqpZdwrs75