### PR TITLE
Enhance CI/CD security and reliability with actionlint and locked builds

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
   # Run on changes to dependency files
   push:
+    branches: [main]
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -43,10 +46,10 @@ jobs:
       - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
 
       - name: Clippy (default features)
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Clippy (all features)
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --locked --all-features --all-targets -- -D warnings
 
   test:
     name: Test (${{ matrix.os }})
@@ -64,10 +67,10 @@ jobs:
       - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
 
       - name: Run tests
-        run: cargo test --all-features --all-targets
+        run: cargo test --locked --all-features --all-targets
 
       - name: Run doc tests
-        run: cargo test --all-features --doc
+        run: cargo test --locked --all-features --doc
 
   deny:
     name: Dependency audit
@@ -100,6 +103,7 @@ jobs:
         uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   semver:
@@ -110,3 +114,16 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+
+  actionlint:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Run actionlint
+        run: ./actionlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:
@@ -29,6 +29,12 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
+      - name: Validate tag ref
+        if: github.ref_type != 'tag'
+        run: |
+          echo "::error::Release workflow must be triggered by a tag push, not a branch."
+          exit 1
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -40,9 +46,6 @@ jobs:
         run: sudo apt-get install -y musl-tools
 
       - uses: Swatinem/rust-cache@401aff9a7a08acb9d27b64936a90db81024cff97 # v2.8.2
-
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload binary to release
         uses: taiki-e/upload-rust-binary-action@57510bf386b3945b57963e73201cea60ca18dff4 # v1.9.1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,9 @@ pre-commit:
       run: cargo fmt --all -- --check
     clippy:
       run: cargo clippy -- -D warnings
+    actionlint:
+      glob: ".github/workflows/*.{yml,yaml}"
+      run: actionlint {staged_files}
 
 pre-push:
   commands:


### PR DESCRIPTION
## Summary
This PR improves the CI/CD pipeline security, reliability, and code quality by adding GitHub Actions linting, enforcing locked dependency resolution, and implementing stricter release validation.

## Key Changes

- **Security & Permissions**: Added explicit `permissions: contents: read` to the CI workflow to follow the principle of least privilege
- **Locked Builds**: Added `--locked` flag to all Cargo commands (clippy, test) to ensure reproducible builds using the lockfile
- **All Targets**: Added `--all-targets` flag to clippy checks to lint all targets including tests and examples
- **GitHub Actions Linting**: 
  - Added new `actionlint` job to CI workflow to validate GitHub Actions workflow files
  - Integrated actionlint into pre-commit hooks for local validation
- **Release Workflow Improvements**:
  - Refined tag pattern from `v[0-9]+.*` to `v[0-9]+.[0-9]+.[0-9]+*` for stricter semantic versioning
  - Added validation step to ensure release workflow is only triggered by tag pushes, not branch pushes
  - Removed redundant `cargo build --release` step (handled by upload-rust-binary-action)
- **Codecov Integration**: Added explicit `CODECOV_TOKEN` secret to codecov-action for improved reliability
- **Audit Workflow**: Restricted audit workflow to run only on `main` branch to reduce noise from feature branches

## Notable Details

- The `--locked` flag ensures builds are reproducible and prevents unexpected dependency updates
- Actionlint validation catches common GitHub Actions configuration errors early
- The release workflow validation prevents accidental releases from non-tag pushes
- All changes maintain backward compatibility while improving CI robustness

https://claude.ai/code/session_01SZxjvDzkDok9TfAg18ZUsC