### PR TITLE
Enhance benchmarks, add force mode validation, and improve error messages

### DIFF
--- a/benches/toggle_bench.rs
+++ b/benches/toggle_bench.rs
@@ -1,13 +1,27 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::fs::File;
-use std::io::{self, Read, Write};
+use std::fs;
+use std::io::{self, Write};
 use std::path::Path;
-use toggle::core::{toggle_comments, LineRange};
+use toggle::core::{
+    find_and_toggle_section, toggle_comments, toggle_comments_multi, CommentStyle, LineRange,
+};
 
-// Create a fixture file with alternating commented and uncommented lines
+/// Generate fixture content with alternating commented and uncommented lines.
+fn generate_fixture(num_lines: usize) -> String {
+    let mut buf = String::new();
+    for i in 0..num_lines {
+        if i % 2 == 0 {
+            buf.push_str(&format!("# This is a commented line {}\n", i + 1));
+        } else {
+            buf.push_str(&format!("print('This is an uncommented line {}')\n", i + 1));
+        }
+    }
+    buf
+}
+
+/// Create a fixture file on disk (used for CLI benchmarks).
 fn create_fixture_file(path: &Path, num_lines: usize) -> io::Result<()> {
-    let mut file = File::create(path)?;
-
+    let mut file = fs::File::create(path)?;
     for i in 0..num_lines {
         if i % 2 == 0 {
             writeln!(file, "# This is a commented line {}", i + 1)?;
@@ -15,37 +29,63 @@ fn create_fixture_file(path: &Path, num_lines: usize) -> io::Result<()> {
             writeln!(file, "print('This is an uncommented line {}')", i + 1)?;
         }
     }
-
     Ok(())
 }
 
-// Read the entire contents of a file
-fn read_file_contents(path: &Path) -> io::Result<String> {
-    let mut file = File::open(path)?;
-    let mut content = String::new();
-    file.read_to_string(&mut content)?;
-    Ok(content)
+/// Generate content with section markers for section-toggle benchmarks.
+fn generate_section_content(num_sections: usize, lines_per_section: usize) -> String {
+    let mut buf = String::new();
+    for s in 0..num_sections {
+        buf.push_str(&format!("# toggle:start ID=section{}\n", s));
+        for l in 0..lines_per_section {
+            buf.push_str(&format!("print('section {} line {}')\n", s, l + 1));
+        }
+        buf.push_str(&format!("# toggle:end ID=section{}\n", s));
+    }
+    buf
 }
 
+// ── Single-file toggle at various sizes ─────────────────────────────────────
+
+fn bench_toggle_by_size(c: &mut Criterion) {
+    let small = generate_fixture(50);
+    let medium = generate_fixture(500);
+    let large = generate_fixture(5000);
+
+    c.bench_function("toggle_small_50", |b| {
+        b.iter(|| {
+            let ranges = vec![LineRange::new(1, 50)];
+            toggle_comments(black_box(&small), black_box(&ranges), None)
+        })
+    });
+
+    c.bench_function("toggle_medium_500", |b| {
+        b.iter(|| {
+            let ranges = vec![LineRange::new(1, 500)];
+            toggle_comments(black_box(&medium), black_box(&ranges), None)
+        })
+    });
+
+    c.bench_function("toggle_large_5000", |b| {
+        b.iter(|| {
+            let ranges = vec![LineRange::new(1, 5000)];
+            toggle_comments(black_box(&large), black_box(&ranges), None)
+        })
+    });
+}
+
+// ── Original 1000-line benchmarks ───────────────────────────────────────────
+
 fn bench_toggle_comments(c: &mut Criterion) {
-    let fixture_path = Path::new("benches/fixture_1000.py");
+    let content = generate_fixture(1000);
 
-    // Only create the fixture file if it doesn't exist
-    if !fixture_path.exists() {
-        create_fixture_file(fixture_path, 1000).expect("Failed to create fixture file");
-    }
-
-    let content = read_file_contents(fixture_path).expect("Failed to read fixture file");
-
-    // Benchmark toggling the entire file
-    c.bench_function("toggle_all", |b| {
+    c.bench_function("toggle_all_1000", |b| {
         b.iter(|| {
             let ranges = vec![LineRange::new(1, 1000)];
             toggle_comments(black_box(&content), black_box(&ranges), None)
         })
     });
 
-    // Benchmark toggling specific ranges (first 100 lines)
     c.bench_function("toggle_range_100", |b| {
         b.iter(|| {
             let ranges = vec![LineRange::new(1, 100)];
@@ -54,5 +94,104 @@ fn bench_toggle_comments(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_toggle_comments);
+// ── Multi-line (block) comment toggle ───────────────────────────────────────
+
+fn bench_toggle_multi(c: &mut Criterion) {
+    // Generate JS-style content for block comments
+    let mut content = String::new();
+    for i in 0..1000 {
+        content.push_str(&format!("console.log('line {}');\n", i + 1));
+    }
+
+    c.bench_function("toggle_multi_1000", |b| {
+        b.iter(|| {
+            let ranges = vec![LineRange::new(1, 1000)];
+            toggle_comments_multi(
+                black_box(&content),
+                black_box(&ranges),
+                None,
+                "/*",
+                "*/",
+            )
+        })
+    });
+}
+
+// ── Section discovery and toggle ────────────────────────────────────────────
+
+fn bench_section_toggle(c: &mut Criterion) {
+    let content = generate_section_content(20, 10);
+    let style = CommentStyle {
+        single_line: "#".to_string(),
+        multi_line_start: None,
+        multi_line_end: None,
+    };
+
+    c.bench_function("section_toggle_single", |b| {
+        b.iter(|| {
+            let mut lines: Vec<String> = content.lines().map(String::from).collect();
+            find_and_toggle_section(
+                black_box(&mut lines),
+                black_box("section10"),
+                &None,
+                &style,
+            )
+            .unwrap()
+        })
+    });
+
+    c.bench_function("section_toggle_all_20", |b| {
+        b.iter(|| {
+            let mut lines: Vec<String> = content.lines().map(String::from).collect();
+            for i in 0..20 {
+                let id = format!("section{}", i);
+                find_and_toggle_section(black_box(&mut lines), &id, &None, &style).unwrap();
+            }
+        })
+    });
+}
+
+// ── CLI integration: 100-file directory traversal ───────────────────────────
+
+fn bench_cli_100_files(c: &mut Criterion) {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let mut paths: Vec<String> = Vec::new();
+
+    for i in 0..100 {
+        let file_path = dir.path().join(format!("file_{}.py", i));
+        create_fixture_file(&file_path, 50).expect("Failed to create fixture file");
+        paths.push(file_path.to_str().unwrap().to_string());
+    }
+
+    // Build the binary path once
+    let binary = env!("CARGO_BIN_EXE_toggle");
+
+    c.bench_function("cli_100_files", |b| {
+        // Re-create files each iteration since toggle modifies them
+        b.iter_batched(
+            || {
+                for (i, p) in paths.iter().enumerate() {
+                    create_fixture_file(Path::new(p), 50)
+                        .unwrap_or_else(|_| panic!("Failed to recreate file {}", i));
+                }
+            },
+            |()| {
+                let mut cmd = std::process::Command::new(binary);
+                cmd.args(&paths).args(["-l", "1:10"]);
+                let output = cmd.output().expect("Failed to run toggle");
+                assert!(output.status.success(), "toggle exited with error");
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_toggle_by_size,
+    bench_toggle_comments,
+    bench_toggle_multi,
+    bench_section_toggle,
+    bench_cli_100_files,
+);
 criterion_main!(benches);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,8 +18,8 @@ pub struct Cli {
     #[arg(short = 'S', long = "section", action = clap::ArgAction::Append)]
     pub sections: Vec<String>,
 
-    /// Force toggle state (on/off)
-    #[arg(short = 'f', long = "force")]
+    /// Force toggle state (on/off/invert)
+    #[arg(short = 'f', long = "force", visible_short_alias = 'F')]
     pub force: Option<String>,
 
     /// Comment mode (auto/single/multi)

--- a/src/core.rs
+++ b/src/core.rs
@@ -418,7 +418,13 @@ pub fn get_comment_style(
     comment_styles
         .get(extension)
         .cloned()
-        .ok_or_else(|| UsageError(format!("Unsupported file extension: .{}", extension)).into())
+        .ok_or_else(|| {
+            UsageError(format!(
+                "Unsupported file extension: .{}; use --comment-style or --config with a [global] single_line_delimiter",
+                extension
+            ))
+            .into()
+        })
 }
 
 /// Find section markers and toggle the content between them.

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,18 @@ fn run(cli: &Cli) -> Result<()> {
         cli.mode.clone()
     };
 
-    let effective_force = if cli.force.is_some() {
-        cli.force.clone()
+    let effective_force = if let Some(ref val) = cli.force {
+        match val.as_str() {
+            "on" | "off" => cli.force.clone(),
+            "invert" => None,
+            other => {
+                return Err(UsageError(format!(
+                    "Invalid --force value '{}': expected on, off, or invert",
+                    other
+                ))
+                .into());
+            }
+        }
     } else {
         config
             .as_ref()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -774,3 +774,123 @@ fn test_json_with_dry_run() {
     let after = fs::read_to_string(&path).unwrap();
     assert_eq!(after, "hello\nworld\n");
 }
+
+// ── -F alias and --force invert value ───────────────────────────────────────
+
+#[test]
+fn test_force_uppercase_f_alias_on() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-F", "on", "-l", "1:2"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "# a\n# b\nc\n");
+}
+
+#[test]
+fn test_force_uppercase_f_alias_off() {
+    let (_dir, path) = setup_temp_file("# a\n# b\nc\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-F", "off", "-l", "1:2"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "a\nb\nc\n");
+}
+
+#[test]
+fn test_force_invert_value_comments_then_uncomments() {
+    let (_dir, path) = setup_temp_file("a\nb\nc\n", "test.py");
+    // First pass: invert on uncommented lines → comments them
+    cmd()
+        .args([path.to_str().unwrap(), "-f", "invert", "-l", "1:2"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "# a\n# b\nc\n");
+    // Second pass: invert on commented lines → uncomments them
+    cmd()
+        .args([path.to_str().unwrap(), "--force", "invert", "-l", "1:2"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "a\nb\nc\n");
+}
+
+#[test]
+fn test_force_invert_with_uppercase_f() {
+    let (_dir, path) = setup_temp_file("a\nb\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "-F", "invert", "-l", "1:2"])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&path).unwrap();
+    assert_eq!(result, "# a\n# b\n");
+}
+
+#[test]
+fn test_force_invalid_value_errors() {
+    let (_dir, path) = setup_temp_file("a\nb\n", "test.py");
+    cmd()
+        .args([path.to_str().unwrap(), "--force", "bogus", "-l", "1:2"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid --force value 'bogus'"));
+}
+
+// ── Unknown extension fallback to config ────────────────────────────────────
+
+#[test]
+fn test_unknown_extension_with_global_config_delimiter() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("data.xyz");
+    fs::write(&file_path, "line one\nline two\n").unwrap();
+
+    let config_path = dir.path().join(".toggleConfig");
+    fs::write(
+        &config_path,
+        "[global]\nsingle_line_delimiter = \"//\"\n",
+    )
+    .unwrap();
+
+    cmd()
+        .args([
+            file_path.to_str().unwrap(),
+            "-l",
+            "1:2",
+            "--config",
+            config_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let result = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(result, "// line one\n// line two\n");
+}
+
+#[test]
+fn test_unknown_extension_without_config_errors() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("data.xyz");
+    fs::write(&file_path, "line one\nline two\n").unwrap();
+
+    cmd()
+        .args([file_path.to_str().unwrap(), "-l", "1:2"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unsupported file extension: .xyz"));
+}
+
+#[test]
+fn test_unknown_extension_error_suggests_alternatives() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("data.xyz");
+    fs::write(&file_path, "line one\n").unwrap();
+
+    cmd()
+        .args([file_path.to_str().unwrap(), "-l", "1:1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--comment-style"))
+        .stderr(predicate::str::contains("--config"));
+}


### PR DESCRIPTION
## Summary
This PR expands the benchmark suite with comprehensive performance tests across different file sizes and features, adds validation for the `--force` flag with support for an "invert" mode, and improves error messages for unsupported file extensions.

## Key Changes

### Benchmarks (`benches/toggle_bench.rs`)
- **Refactored fixture generation**: Replaced file I/O with in-memory string generation for faster, more flexible benchmarks
- **Added size-based benchmarks**: New `bench_toggle_by_size()` function benchmarks performance on 50, 500, and 5000-line files
- **Added multi-line comment benchmarks**: New `bench_toggle_multi()` function tests block comment toggling (e.g., `/* */`)
- **Added section toggle benchmarks**: New `bench_section_toggle()` function benchmarks section discovery and toggling
- **Added CLI integration benchmarks**: New `bench_cli_100_files()` function benchmarks the CLI across 100 files with directory traversal
- **Organized benchmarks with section comments**: Added clear visual separators for different benchmark categories

### Force Mode Validation (`src/main.rs` and `src/cli.rs`)
- **Added validation for `--force` values**: Now accepts "on", "off", or "invert"; rejects invalid values with helpful error message
- **Added `-F` uppercase alias**: Short form `-F` now available as an alias for `--force`
- **Implemented "invert" mode**: When force is set to "invert", the effective force is `None`, allowing toggle to invert the current state
- **Improved error handling**: Invalid force values now return a clear error message listing accepted values

### Error Messages (`src/core.rs`)
- **Enhanced unsupported extension error**: Now suggests using `--comment-style` or `--config` with a `[global] single_line_delimiter` as alternatives

### Integration Tests (`tests/integration.rs`)
- **Added force mode tests**: Tests for `-F` alias, "on"/"off" values, and "invert" behavior
- **Added force validation tests**: Tests for invalid force values and error messages
- **Added unknown extension tests**: Tests for fallback to config, error handling, and helpful error suggestions

## Implementation Details
- The "invert" force mode works by setting `effective_force` to `None`, which allows the toggle logic to determine the state based on the current content
- Benchmark fixtures are now generated in-memory using helper functions (`generate_fixture()`, `generate_section_content()`) for better performance and flexibility
- CLI integration benchmarks use `tempfile` crate and `iter_batched()` to properly reset file state between iterations

https://claude.ai/code/session_01Pim6srmSj6u4fSkE6aVqe9