### PR TITLE
Refactor file collection and comment style lookup

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,6 @@
 // Toggle algorithm implementation
 
 use anyhow::Result;
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::config::ToggleConfig;
@@ -564,69 +563,44 @@ pub fn get_comment_style(
         }
     }
 
-    let mut comment_styles = HashMap::new();
-    // Hash-style comments (no multi-line)
-    for ext in &[
-        "py", "sh", "rb", "yaml", "yml", "toml", "r", "ex", "exs", "pl", "pm",
-    ] {
-        comment_styles.insert(
-            *ext,
-            CommentStyle {
+    match extension {
+        // Hash-style comments (no multi-line)
+        "py" | "sh" | "rb" | "yaml" | "yml" | "toml" | "r" | "ex" | "exs" | "pl" | "pm" => {
+            Ok(CommentStyle {
                 single_line: "#".to_string(),
                 multi_line_start: None,
                 multi_line_end: None,
-            },
-        );
-    }
-    // Slash-style comments with /* */ multi-line
-    for ext in &[
-        "js", "jsx", "ts", "tsx", "rs", "java", "c", "cpp", "go", "swift", "kt", "scala", "php",
-    ] {
-        comment_styles.insert(
-            *ext,
-            CommentStyle {
-                single_line: "//".to_string(),
-                multi_line_start: Some("/*".to_string()),
-                multi_line_end: Some("*/".to_string()),
-            },
-        );
-    }
-    // Dash-style comments
-    comment_styles.insert(
-        "lua",
-        CommentStyle {
+            })
+        }
+        // Slash-style comments with /* */ multi-line
+        "js" | "jsx" | "ts" | "tsx" | "rs" | "java" | "c" | "cpp" | "go" | "swift" | "kt"
+        | "scala" | "php" => Ok(CommentStyle {
+            single_line: "//".to_string(),
+            multi_line_start: Some("/*".to_string()),
+            multi_line_end: Some("*/".to_string()),
+        }),
+        // Dash-style comments
+        "lua" => Ok(CommentStyle {
             single_line: "--".to_string(),
             multi_line_start: Some("--[[".to_string()),
             multi_line_end: Some("]]".to_string()),
-        },
-    );
-    comment_styles.insert(
-        "hs",
-        CommentStyle {
+        }),
+        "hs" => Ok(CommentStyle {
             single_line: "--".to_string(),
             multi_line_start: Some("{-".to_string()),
             multi_line_end: Some("-}".to_string()),
-        },
-    );
-    comment_styles.insert(
-        "sql",
-        CommentStyle {
+        }),
+        "sql" => Ok(CommentStyle {
             single_line: "--".to_string(),
             multi_line_start: Some("/*".to_string()),
             multi_line_end: Some("*/".to_string()),
-        },
-    );
-
-    comment_styles
-        .get(extension)
-        .cloned()
-        .ok_or_else(|| {
-            UsageError(format!(
-                "Unsupported file extension: .{}; use --comment-style or --config with a [global] single_line_delimiter",
-                extension
-            ))
-            .into()
-        })
+        }),
+        _ => Err(UsageError(format!(
+            "Unsupported file extension: .{}; use --comment-style or --config with a [global] single_line_delimiter",
+            extension
+        ))
+        .into()),
+    }
 }
 
 /// Find section markers and toggle the content between them.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 use toggle::cli::Cli;
 use toggle::config::ToggleConfig;
@@ -28,7 +27,6 @@ struct ToggleOptions<'a> {
     to_end: bool,
     comment_style_override: &'a [String],
     interactive: bool,
-    recursive: bool,
 }
 
 /// Result of processing a single toggle operation.
@@ -224,7 +222,6 @@ fn run(cli: &Cli) -> Result<()> {
         to_end: cli.to_end,
         comment_style_override: &cli.comment_style,
         interactive: cli.interactive,
-        recursive: cli.recursive,
     };
 
     if cli.list_sections {
@@ -234,38 +231,6 @@ fn run(cli: &Cli) -> Result<()> {
     } else {
         run_normal(cli, &opts)
     }
-}
-
-/// Expand CLI paths into individual files, walking directories when recursive is set.
-fn collect_files(paths: &[PathBuf], recursive: bool) -> Vec<PathBuf> {
-    if !recursive {
-        return paths.to_vec();
-    }
-    let mut files = Vec::new();
-    for path in paths {
-        if path.is_file() {
-            files.push(path.clone());
-        } else if path.is_dir() {
-            for entry in WalkDir::new(path)
-                .follow_links(false)
-                .into_iter()
-                .filter_entry(|e| {
-                    // Always include the root directory (depth 0), only filter
-                    // hidden entries in subdirectories
-                    e.depth() == 0 || !e.file_name().to_str().is_some_and(|s| s.starts_with('.'))
-                })
-                .filter_map(|e| e.ok())
-            {
-                if entry.file_type().is_file() {
-                    files.push(entry.into_path());
-                }
-            }
-        } else {
-            // Non-existent or special paths: include as-is to let process_path report errors
-            files.push(path.clone());
-        }
-    }
-    files
 }
 
 /// Check if a file has any sections matching the requested IDs.
@@ -282,52 +247,54 @@ fn file_has_matching_sections(path: &Path, section_ids: &[String], encoding: &st
     found.iter().any(|s| section_ids.contains(&s.id))
 }
 
-fn run_normal(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
-    let files = collect_files(&cli.paths, cli.recursive);
+/// Collect files from CLI paths and apply recursive-mode filters
+/// (section matching + extension support).
+fn collect_and_filter_files(cli: &Cli, opts: &ToggleOptions) -> Result<Vec<PathBuf>> {
+    let walk_opts = walk::WalkOptions {
+        verbose: opts.verbose,
+        skip_unsupported_extensions: false,
+        ..walk::WalkOptions::default()
+    };
+    let files = walk::collect_files(&cli.paths, cli.recursive, &walk_opts)?;
 
+    Ok(files
+        .into_iter()
+        .filter(|path| {
+            // In recursive mode with sections, skip files without matching sections
+            if cli.recursive
+                && !cli.sections.is_empty()
+                && !file_has_matching_sections(path, &cli.sections, opts.encoding)
+            {
+                return false;
+            }
+            // In recursive mode, silently skip files with unsupported extensions
+            if cli.recursive
+                && opts.comment_style_override.is_empty()
+                && core::get_comment_style(path, opts.mode, opts.config).is_err()
+            {
+                return false;
+            }
+            true
+        })
+        .collect())
+}
+
+fn run_normal(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
+    let files = collect_and_filter_files(cli, opts)?;
     for path in &files {
-        // In recursive mode with sections, skip files that don't contain matching sections
-        if cli.recursive
-            && !cli.sections.is_empty()
-            && !file_has_matching_sections(path, &cli.sections, opts.encoding)
-        {
-            continue;
-        }
-        // In recursive mode, silently skip files with unsupported extensions
-        if cli.recursive
-            && opts.comment_style_override.is_empty()
-            && core::get_comment_style(path, opts.mode, opts.config).is_err()
-        {
-            continue;
-        }
-        process_path(path, cli, opts)
+        process_file(path, cli, opts)
             .with_context(|| format!("Failed to process {}", path.display()))?;
     }
     Ok(())
 }
 
 fn run_json(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
-    let files = collect_files(&cli.paths, cli.recursive);
+    let files = collect_and_filter_files(cli, opts)?;
     let mut results: Vec<ToggleResult> = Vec::new();
     let mut had_error = false;
 
     for path in &files {
-        // In recursive mode with sections, skip files that don't contain matching sections
-        if cli.recursive
-            && !cli.sections.is_empty()
-            && !file_has_matching_sections(path, &cli.sections, opts.encoding)
-        {
-            continue;
-        }
-        // In recursive mode, silently skip files with unsupported extensions
-        if cli.recursive
-            && opts.comment_style_override.is_empty()
-            && core::get_comment_style(path, opts.mode, opts.config).is_err()
-        {
-            continue;
-        }
-
-        match process_path(path, cli, opts) {
+        match process_file(path, cli, opts) {
             Ok(proc_results) => {
                 for pr in proc_results {
                     results.push(ToggleResult {
@@ -373,7 +340,12 @@ fn run_json(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
 type SectionAggregation = (Option<String>, Vec<(String, usize, usize)>);
 
 fn run_list_sections(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
-    let files = collect_files(&cli.paths, cli.recursive);
+    let walk_opts = walk::WalkOptions {
+        verbose: opts.verbose,
+        skip_unsupported_extensions: false,
+        ..walk::WalkOptions::default()
+    };
+    let files = walk::collect_files(&cli.paths, cli.recursive, &walk_opts)?;
 
     // Aggregate sections grouped by ID, preserving insertion order with BTreeMap
     let mut sections_by_id: BTreeMap<String, SectionAggregation> = BTreeMap::new();
@@ -434,44 +406,6 @@ fn run_list_sections(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn process_path(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<ProcessResult>> {
-    // If path is a directory, handle recursive traversal
-    if path.is_dir() {
-        if !opts.recursive {
-            return Err(UsageError(format!(
-                "'{}' is a directory; use -R/--recursive to process directories",
-                path.display()
-            ))
-            .into());
-        }
-        let mut results = Vec::new();
-        for entry in WalkDir::new(path)
-            .into_iter()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().is_file())
-        {
-            let file_path = entry.path();
-            // Skip files with unsupported extensions (unless --comment-style is set)
-            if opts.comment_style_override.is_empty()
-                && core::get_comment_style(file_path, opts.mode, opts.config).is_err()
-            {
-                continue;
-            }
-            match process_file(file_path, cli, opts) {
-                Ok(mut file_results) => results.append(&mut file_results),
-                Err(e) => {
-                    if opts.verbose {
-                        eprintln!("  Skipping {}: {}", file_path.display(), e);
-                    }
-                }
-            }
-        }
-        return Ok(results);
-    }
-
-    process_file(path, cli, opts)
 }
 
 fn process_file(path: &Path, cli: &Cli, opts: &ToggleOptions) -> Result<Vec<ProcessResult>> {

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -12,6 +12,9 @@ pub struct WalkOptions {
     pub skip_hidden: bool,
     pub max_depth: Option<usize>,
     pub verbose: bool,
+    /// When true, only collect files with extensions in `supported_extensions()`.
+    /// When false, collect all files (callers handle extension filtering themselves).
+    pub skip_unsupported_extensions: bool,
 }
 
 impl Default for WalkOptions {
@@ -20,6 +23,7 @@ impl Default for WalkOptions {
             skip_hidden: true,
             max_depth: None,
             verbose: false,
+            skip_unsupported_extensions: true,
         }
     }
 }
@@ -75,7 +79,7 @@ pub fn collect_files(
         } else if path.is_dir() {
             if !recursive {
                 return Err(UsageError(format!(
-                    "'{}' is a directory; use --recursive (-R) to process directories",
+                    "'{}' is a directory; use -R/--recursive to process directories",
                     path.display()
                 ))
                 .into());
@@ -111,7 +115,9 @@ fn walk_directory(dir: &Path, opts: &WalkOptions, files: &mut Vec<PathBuf>) -> R
     }) {
         match entry {
             Ok(entry) => {
-                if entry.file_type().is_file() && is_supported_file(entry.path()) {
+                if entry.file_type().is_file()
+                    && (!opts.skip_unsupported_extensions || is_supported_file(entry.path()))
+                {
                     files.push(entry.into_path());
                 }
             }

--- a/tests/unit/walk_tests.rs
+++ b/tests/unit/walk_tests.rs
@@ -136,6 +136,7 @@ fn test_collect_files_max_depth() {
         skip_hidden: true,
         max_depth: Some(2), // root + 1 level
         verbose: false,
+        skip_unsupported_extensions: true,
     };
     let files = collect_files(&[dir.path().to_path_buf()], true, &opts).unwrap();
     assert!(files.iter().any(|f| f.ends_with("top.py")));


### PR DESCRIPTION
## Summary
This PR refactors the file collection and comment style lookup logic to improve code organization and reduce duplication. The main changes involve moving file walking logic to a dedicated module and simplifying the comment style matching.

## Key Changes

- **Removed `collect_files()` function** from `main.rs` and moved file collection logic to the `walk` module, which now handles both recursive and non-recursive file discovery
- **Removed `process_path()` function** that handled directory traversal; file filtering is now consolidated in `collect_and_filter_files()`
- **Refactored `get_comment_style()` in `core.rs`** from HashMap-based lookup to a match expression for better performance and clarity
- **Consolidated filtering logic** into `collect_and_filter_files()` which applies section matching and extension filtering in one pass, eliminating duplicate filter checks in `run_normal()` and `run_json()`
- **Added `skip_unsupported_extensions` option** to `WalkOptions` to allow callers to control whether unsupported file extensions are filtered during collection
- **Removed `recursive` field** from `ToggleOptions` struct since it's already available in `Cli`
- **Removed unused `walkdir` import** from `main.rs` (now only used in `walk` module)

## Implementation Details

- The `walk::collect_files()` function now serves as the single entry point for file collection, handling both recursive and non-recursive modes
- File filtering (sections and extensions) is now applied consistently across all code paths via `collect_and_filter_files()`
- The `run_list_sections()` function directly calls `walk::collect_files()` without filtering, as it needs to examine all files
- Comment style matching now uses Rust's pattern matching instead of HashMap lookups, which is more idiomatic and potentially more efficient

https://claude.ai/code/session_011AZL4PUj8skzD1zW8nrPSk