### PR TITLE
ci: cbindgen header-drift gate + just gen-c-header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,25 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint
+
+  cbindgen-drift:
+    name: C header drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      # Pin cbindgen to the lockfile version so generated output matches build.rs.
+      - uses: taiki-e/install-action@899b013517f9e7774591216672bf75a46bb9a481 # v2.9.4
+        with:
+          tool: cbindgen@0.27.0
+
+      # Mirror of `just gen-c-header`, invoked directly: the CI-bundled `just`
+      # predates the `[group(...)]` attribute the Justfile uses.
+      - name: Regenerate the committed C header
+        run: cbindgen --config crates/togl-ffi/cbindgen.toml --output crates/togl-ffi/include/togl.h crates/togl-ffi
+
+      - name: Fail if the committed header is out of date
+        run: git diff --exit-code crates/togl-ffi/include/togl.h

--- a/Justfile
+++ b/Justfile
@@ -129,6 +129,13 @@ alias rr := run-release
 
 alias b := build
 
+# Regenerate the committed C header (cbindgen) for the togl-ffi crate.
+# Run after changing the `extern "C"` surface in crates/togl-ffi/src/.
+# Requires `cargo install cbindgen` (pinned to the lockfile version in CI).
+[group('build')]
+@gen-c-header:
+    cbindgen --config crates/togl-ffi/cbindgen.toml --output crates/togl-ffi/include/togl.h crates/togl-ffi
+
 # Set up pre-commit hooks (install lefthook hooks into .git)
 [group('pre-commit')]
 @pre-commit-setup:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,6 +11,12 @@ pre-commit:
     toml-lint:
       glob: "*.toml"
       run: taplo fmt --check {staged_files}
+    # When the togl-ffi FFI surface changes, regenerate the committed C header
+    # and stage it, so a stale togl.h can't be committed. Reuses the same
+    # `just gen-c-header` the CI drift gate runs. Requires `cargo install cbindgen`.
+    gen-c-header:
+      glob: "crates/togl-ffi/**"
+      run: just gen-c-header && git add crates/togl-ffi/include/togl.h
 
 pre-push:
   commands:


### PR DESCRIPTION
Prevents the committed `crates/togl-ffi/include/togl.h` from drifting out of sync with the FFI surface.

- **`just gen-c-header`** — single regenerate command (cbindgen, lockfile-pinned 0.27.0)
- **CI `cbindgen-drift` job** — runs `just gen-c-header` then `git diff --exit-code` → fails on stale header
- **lefthook pre-commit** — runs `just gen-c-header` + stages it when `crates/togl-ffi/**` changes (auto-fix), reusing the same just recipe (DRY)

Verified: clean tree passes; a corrupted header fails the gate; `gen-c-header` restores it. cbindgen CLI output is byte-identical to the build.rs Builder output (both 0.27.0).