### PR TITLE
feat(cli): --fields filter for --list-sections (P07)

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -127,8 +127,24 @@ See `docs/superpowers/specs/2026-05-29-marker-insert-strip-list-filters-design.m
 
 ---
 
-> **Note:** P06 (`--remove`) and P07 (list filters) remain reserved for the marker
-> roadmap. The C ABI library is numbered P08.
+> **Note:** P06 (`--remove`) remains reserved for the marker roadmap (not started).
+> The C ABI library is numbered P08; release automation P09.
+
+## [x] Project P07: List filters (`--fields`) (v0.5.0)
+**Goal**: Add `--fields ids|files|lines` to `--list-sections` to filter its text
+output. Default `lines` keeps current behavior (backward compatible); `--json`
+is unaffected. See `docs/superpowers/specs/2026-05-29-marker-insert-strip-list-filters-design.md` §P07.
+
+### Tests & Tasks
+- [x] [P07-T01] `ListFields` enum (clap `ValueEnum`) + `--fields` arg in `cli.rs`
+- [x] [P07-T02] Guard: `--fields` requires `--list-sections`
+- [x] [P07-T03] Branch `run_list_sections` text output on the level (ids / files / lines)
+- [x] [P07-TS01] Integration tests: each level, `lines` == default, `--json` unchanged, requires-guard
+
+### Automated Verification
+- `cargo test --workspace` green (5 new integration tests; integration 130 → 135)
+- `cargo clippy --workspace --all-targets -- -D warnings` clean
+- `--fields lines` output byte-identical to prior behavior
 
 ## [x] Project P08: ABI-Stable C Library (`libtogl`) (v0.3.0)
 **Goal**: Add a `togl-ffi` workspace crate exposing an ABI-stable C library

--- a/crates/togl-cli/src/cli.rs
+++ b/crates/togl-cli/src/cli.rs
@@ -4,6 +4,17 @@ use clap::Parser;
 use clap_complete::Shell;
 use std::path::PathBuf;
 
+/// Output detail level for `--list-sections` (P07).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ListFields {
+    /// Section IDs and descriptions only.
+    Ids,
+    /// IDs plus each file path (no line numbers).
+    Files,
+    /// IDs plus `file:start-end` (current default behavior).
+    Lines,
+}
+
 #[derive(Parser)]
 #[command(author, version, about)]
 pub struct Cli {
@@ -27,6 +38,10 @@ pub struct Cli {
     /// List all section IDs found in files (discovery mode, no toggling)
     #[arg(long = "list-sections")]
     pub list_sections: bool,
+
+    /// Detail level for --list-sections text output [default: lines]
+    #[arg(long = "fields", default_value = "lines")]
+    pub fields: ListFields,
 
     /// Insert a toggle:start/end marker pair around a single -l range (single file).
     /// Requires exactly one -S <ID> and one -l <range>. Leaves the body uncommented.

--- a/crates/togl-cli/src/main.rs
+++ b/crates/togl-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 mod cli;
-use cli::Cli;
+use cli::{Cli, ListFields};
 use togl_lib::config::ToggleConfig;
 use togl_lib::core;
 use togl_lib::exit_codes::{ExitCode, UsageError};
@@ -295,6 +295,9 @@ fn run(cli: &Cli) -> Result<()> {
     }
     if cli.list_sections && cli.force.is_some() {
         return Err(UsageError("--list-sections cannot be combined with --force".into()).into());
+    }
+    if cli.fields != ListFields::Lines && !cli.list_sections {
+        return Err(UsageError("--fields requires --list-sections".into()).into());
     }
 
     // Validate --eol value
@@ -841,8 +844,21 @@ fn run_list_sections(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
             } else {
                 println!("{}", id);
             }
-            for (file, start, end) in locations {
-                println!("  {}:{}-{}", file, start, end);
+            match cli.fields {
+                ListFields::Ids => {}
+                ListFields::Files => {
+                    let mut seen = std::collections::HashSet::new();
+                    for (file, _, _) in locations {
+                        if seen.insert(file) {
+                            println!("  {}", file);
+                        }
+                    }
+                }
+                ListFields::Lines => {
+                    for (file, start, end) in locations {
+                        println!("  {}:{}-{}", file, start, end);
+                    }
+                }
             }
         }
     }

--- a/crates/togl-cli/tests/integration.rs
+++ b/crates/togl-cli/tests/integration.rs
@@ -1269,6 +1269,135 @@ fn test_list_sections_conflicts_with_force_flag() {
         ));
 }
 
+// ── P07: --list-sections --fields <ids|files|lines> ──
+
+// feat1 appears in two files (a.py + sub/c.py); feat2 in one (b.py).
+fn list_fields_fixture() -> tempfile::TempDir {
+    setup_temp_dir_with_files(&[
+        (
+            "a.py",
+            "# toggle:start ID=feat1 desc=\"Feature one\"\nhello\n# toggle:end ID=feat1\n",
+        ),
+        (
+            "b.py",
+            "# toggle:start ID=feat2\nworld\n# toggle:end ID=feat2\n",
+        ),
+        (
+            "sub/c.py",
+            "# toggle:start ID=feat1\nfoo\n# toggle:end ID=feat1\n",
+        ),
+    ])
+}
+
+#[test]
+fn test_list_sections_fields_ids() {
+    let dir = list_fields_fixture();
+    let output = cmd()
+        .args([
+            dir.path().to_str().unwrap(),
+            "-R",
+            "--list-sections",
+            "--fields",
+            "ids",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("feat1") && stdout.contains("feat2"));
+    assert!(stdout.contains("Feature one"), "ids keeps descriptions");
+    assert!(
+        !stdout.contains(".py"),
+        "ids mode must not show file paths: {stdout}"
+    );
+}
+
+#[test]
+fn test_list_sections_fields_files() {
+    let dir = list_fields_fixture();
+    let output = cmd()
+        .args([
+            dir.path().to_str().unwrap(),
+            "-R",
+            "--list-sections",
+            "--fields",
+            "files",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("a.py") && stdout.contains("c.py"));
+    assert!(
+        !stdout.contains(":1-"),
+        "files mode must not show line numbers: {stdout}"
+    );
+}
+
+#[test]
+fn test_list_sections_fields_lines_is_default() {
+    let dir = list_fields_fixture();
+    let default_out = cmd()
+        .args([dir.path().to_str().unwrap(), "-R", "--list-sections"])
+        .output()
+        .unwrap();
+    let explicit_out = cmd()
+        .args([
+            dir.path().to_str().unwrap(),
+            "-R",
+            "--list-sections",
+            "--fields",
+            "lines",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        default_out.stdout, explicit_out.stdout,
+        "lines is the default (output unchanged)"
+    );
+    let stdout = String::from_utf8(default_out.stdout).unwrap();
+    assert!(
+        stdout.contains(":1-"),
+        "lines mode shows file:start-end: {stdout}"
+    );
+}
+
+#[test]
+fn test_list_sections_fields_requires_list_sections() {
+    let dir = setup_temp_dir_with_files(&[("a.py", "hello\n")]);
+    cmd()
+        .args([dir.path().join("a.py").to_str().unwrap(), "--fields", "ids"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--fields requires --list-sections",
+        ));
+}
+
+#[test]
+fn test_list_sections_json_ignores_fields() {
+    let dir = list_fields_fixture();
+    let output = cmd()
+        .args([
+            dir.path().to_str().unwrap(),
+            "-R",
+            "--list-sections",
+            "--fields",
+            "ids",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(v.is_array());
+    assert!(
+        stdout.contains("start_line"),
+        "--json keeps the full structure regardless of --fields: {stdout}"
+    );
+}
+
 // ── Cross-file JSON output ──
 
 #[test]


### PR DESCRIPTION
Implements **P07** from the marker design spec: `--list-sections --fields <ids|files|lines>`.

| `--fields` | Output |
|---|---|
| `ids` | IDs + descriptions only |
| `files` | IDs + file paths (no line numbers, deduped) |
| `lines` *(default)* | IDs + `file:start-end` (current behavior) |

- Default `lines` → text output **and `--json` are byte-identical to before** (backward compatible)
- `--fields` without `--list-sections` errors
- Enum-validated `ListFields` (clap `ValueEnum`) + branch in `run_list_sections`
- 5 new integration tests (each level, default-equivalence, json-unchanged, requires-guard); suite 130 → 135, clippy + fmt clean