### PR TITLE
feat(cli): --remove recursive section strip, 3 modes (P06)

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -127,8 +127,32 @@ See `docs/superpowers/specs/2026-05-29-marker-insert-strip-list-filters-design.m
 
 ---
 
-> **Note:** P06 (`--remove`) remains reserved for the marker roadmap (not started).
-> The C ABI library is numbered P08; release automation P09.
+> **Note:** The marker roadmap (P05–P07) is complete. The C ABI library is
+> numbered P08; release automation P09.
+
+## [x] Project P06: `--remove` (recursive strip, three modes) (v0.6.0)
+**Goal**: Add `--remove -S <ID>` to strip a named section, recursively with `-R`.
+`--remove-mode markers|commented|all` (default `commented`): `markers` deletes
+only the marker lines; `commented` also deletes fully-commented body lines but
+keeps live code; `all` deletes the whole span. Refuses an ambiguous bare variant
+group; `--require-match` exits non-zero on no match. Reuses `--dry-run`/`--backup`.
+See `docs/superpowers/specs/2026-05-29-marker-insert-strip-list-filters-design.md` §P06.
+
+**Out of Scope**
+- `--remove --atomic` (guarded with an error for now; reuse the atomic batch later)
+- Multi-line-delimited (`/* … */`) "fully-wrapped body" detection (single-line prefix handled)
+
+### Tests & Tasks
+- [x] [P06-T01] `core::remove_section(content, id, mode, comment_style) -> (String, usize)` (3 modes, dup-IDs)
+- [x] [P06-TS01] Unit tests: markers / commented / all / duplicate-IDs / not-found
+- [x] [P06-T02] `RemoveMode` enum + `--remove` / `--remove-mode` / `--require-match` in `cli.rs`
+- [x] [P06-T03] `run_remove` in `main.rs` (walk, variant-group refusal, write via `apply_changes`, match counting)
+- [x] [P06-T04] Validation + dispatch; `--remove` conflicts + `--atomic` guard
+- [x] [P06-TS02] Integration tests: each mode, recursive, require-match, not-found, variant refusal, dry-run
+
+### Automated Verification
+- `cargo test --workspace` green (13 new tests; lib 99→104, integration 135→143)
+- `cargo clippy --workspace --all-targets -- -D warnings` clean
 
 ## [x] Project P07: List filters (`--fields`) (v0.5.0)
 **Goal**: Add `--fields ids|files|lines` to `--list-sections` to filter its text

--- a/crates/togl-cli/src/cli.rs
+++ b/crates/togl-cli/src/cli.rs
@@ -15,6 +15,17 @@ pub enum ListFields {
     Lines,
 }
 
+/// What `--remove` strips from a matched section (P06).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum RemoveMode {
+    /// Delete only the two marker lines; keep the body.
+    Markers,
+    /// Delete the markers and fully-commented body lines; keep live code.
+    Commented,
+    /// Delete the entire span (markers + body, including live code).
+    All,
+}
+
 #[derive(Parser)]
 #[command(author, version, about)]
 pub struct Cli {
@@ -42,6 +53,18 @@ pub struct Cli {
     /// Detail level for --list-sections text output [default: lines]
     #[arg(long = "fields", default_value = "lines")]
     pub fields: ListFields,
+
+    /// Remove a named section (requires -S <ID>). Recursive with -R. See --remove-mode.
+    #[arg(long = "remove")]
+    pub remove: bool,
+
+    /// What --remove strips: markers | commented | all [default: commented]
+    #[arg(long = "remove-mode", default_value = "commented")]
+    pub remove_mode: RemoveMode,
+
+    /// With --remove, exit non-zero if -S <ID> matched no sections.
+    #[arg(long = "require-match")]
+    pub require_match: bool,
 
     /// Insert a toggle:start/end marker pair around a single -l range (single file).
     /// Requires exactly one -S <ID> and one -l <range>. Leaves the body uncommented.

--- a/crates/togl-cli/src/main.rs
+++ b/crates/togl-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 mod cli;
-use cli::{Cli, ListFields};
+use cli::{Cli, ListFields, RemoveMode};
 use togl_lib::config::ToggleConfig;
 use togl_lib::core;
 use togl_lib::exit_codes::{ExitCode, UsageError};
@@ -299,6 +299,21 @@ fn run(cli: &Cli) -> Result<()> {
     if cli.fields != ListFields::Lines && !cli.list_sections {
         return Err(UsageError("--fields requires --list-sections".into()).into());
     }
+    // --remove validation (P06)
+    if cli.remove {
+        if cli.sections.len() != 1 {
+            return Err(UsageError("--remove requires exactly one -S <ID>".into()).into());
+        }
+        if cli.insert || cli.list_sections || cli.scan {
+            return Err(UsageError(
+                "--remove cannot be combined with --insert, --list-sections, or --scan".into(),
+            )
+            .into());
+        }
+        if cli.atomic {
+            return Err(UsageError("--remove cannot be combined with --atomic".into()).into());
+        }
+    }
 
     // Validate --eol value
     match cli.eol.as_str() {
@@ -365,6 +380,8 @@ fn run(cli: &Cli) -> Result<()> {
 
     if cli.insert {
         run_insert(cli, &opts)
+    } else if cli.remove {
+        run_remove(cli, &opts)
     } else if cli.list_sections {
         run_list_sections(cli, &opts)
     } else if cli.atomic {
@@ -780,6 +797,84 @@ fn run_insert(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
             start,
             end
         );
+    }
+    Ok(())
+}
+
+fn run_remove(cli: &Cli, opts: &ToggleOptions) -> Result<()> {
+    let id = &cli.sections[0];
+    let mode = match cli.remove_mode {
+        RemoveMode::Markers => core::RemoveMode::Markers,
+        RemoveMode::Commented => core::RemoveMode::Commented,
+        RemoveMode::All => core::RemoveMode::All,
+    };
+
+    let walk_opts = walk::WalkOptions {
+        verbose: opts.verbose,
+        skip_unsupported_extensions: false,
+        ..walk::WalkOptions::default()
+    };
+    let files = walk::collect_files(&cli.paths, cli.recursive, &walk_opts)?;
+
+    // Refuse an ambiguous bare group: `-S db` where db:sqlite / db:postgres exist
+    // and no exact `db` section. Mirrors the toggling group-ambiguity behavior.
+    if !id.contains(':') {
+        let mut has_exact = false;
+        let mut variants = std::collections::BTreeSet::new();
+        for path in &files {
+            if let Ok(content) = io::read_file_encoded(path, opts.encoding) {
+                for s in core::discover_variants(&content, id) {
+                    if &s.id == id {
+                        has_exact = true;
+                    } else {
+                        variants.insert(s.id);
+                    }
+                }
+            }
+        }
+        if !has_exact && variants.len() >= 2 {
+            let list: Vec<String> = variants.into_iter().collect();
+            return Err(UsageError(format!(
+                "section '{}' is a group with {} variants; specify one (e.g. -S {}). variants: {}",
+                id,
+                list.len(),
+                list[0],
+                list.join(", ")
+            ))
+            .into());
+        }
+    }
+
+    let mut total_removed = 0usize;
+    for path in &files {
+        let content = match io::read_file_encoded(path, opts.encoding) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let style = resolve_comment_style(path, opts)?;
+        let (modified, removed) = core::remove_section(&content, id, mode, &style);
+        total_removed += removed;
+        if removed > 0 {
+            let modified = io::normalize_eol(&modified, opts.eol);
+            apply_changes(path, &content, &modified, opts)?;
+            if opts.verbose {
+                eprintln!(
+                    "Removed {} section(s) '{}' from {}",
+                    removed,
+                    id,
+                    path.display()
+                );
+            }
+        }
+    }
+
+    if total_removed == 0 {
+        eprintln!("Warning: -S {} matched no sections", id);
+        if cli.require_match {
+            return Err(
+                UsageError(format!("--require-match: -S {} matched no sections", id)).into(),
+            );
+        }
     }
     Ok(())
 }

--- a/crates/togl-cli/tests/integration.rs
+++ b/crates/togl-cli/tests/integration.rs
@@ -2534,3 +2534,165 @@ fn togl_alias_completions_use_togl_name() {
 fn version_exits_zero() {
     cmd().arg("--version").assert().success();
 }
+
+// ── P06: --remove (markers / commented / all) ──
+
+const REMOVE_FILE: &str =
+    "keep_before\n# toggle:start ID=feat1\n# old_commented\nlive_code\n# toggle:end ID=feat1\nkeep_after\n";
+
+#[test]
+fn test_remove_markers_mode() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    let p = dir.path().join("a.py");
+    cmd()
+        .args([
+            p.to_str().unwrap(),
+            "--remove",
+            "-S",
+            "feat1",
+            "--remove-mode",
+            "markers",
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read_to_string(&p).unwrap(),
+        "keep_before\n# old_commented\nlive_code\nkeep_after\n"
+    );
+}
+
+#[test]
+fn test_remove_commented_is_default() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    let p = dir.path().join("a.py");
+    cmd()
+        .args([p.to_str().unwrap(), "--remove", "-S", "feat1"])
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read_to_string(&p).unwrap(),
+        "keep_before\nlive_code\nkeep_after\n"
+    );
+}
+
+#[test]
+fn test_remove_all_mode() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    let p = dir.path().join("a.py");
+    cmd()
+        .args([
+            p.to_str().unwrap(),
+            "--remove",
+            "-S",
+            "feat1",
+            "--remove-mode",
+            "all",
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read_to_string(&p).unwrap(),
+        "keep_before\nkeep_after\n"
+    );
+}
+
+#[test]
+fn test_remove_recursive_across_files() {
+    let dir = setup_temp_dir_with_files(&[
+        (
+            "a.py",
+            "# toggle:start ID=feat1\nx\n# toggle:end ID=feat1\nA\n",
+        ),
+        (
+            "sub/b.py",
+            "# toggle:start ID=feat1\ny\n# toggle:end ID=feat1\nB\n",
+        ),
+    ]);
+    cmd()
+        .args([
+            dir.path().to_str().unwrap(),
+            "-R",
+            "--remove",
+            "-S",
+            "feat1",
+            "--remove-mode",
+            "all",
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("a.py")).unwrap(),
+        "A\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("sub/b.py")).unwrap(),
+        "B\n"
+    );
+}
+
+#[test]
+fn test_remove_not_found_warns_exit_zero() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    cmd()
+        .args([
+            dir.path().join("a.py").to_str().unwrap(),
+            "--remove",
+            "-S",
+            "nope",
+        ])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("matched no sections"));
+}
+
+#[test]
+fn test_remove_require_match_exits_nonzero() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    cmd()
+        .args([
+            dir.path().join("a.py").to_str().unwrap(),
+            "--remove",
+            "-S",
+            "nope",
+            "--require-match",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_remove_refuses_ambiguous_variant_group() {
+    let dir = setup_temp_dir_with_files(&[(
+        "v.py",
+        "# toggle:start ID=db:sqlite\na\n# toggle:end ID=db:sqlite\n# toggle:start ID=db:postgres\nb\n# toggle:end ID=db:postgres\n",
+    )]);
+    cmd()
+        .args([
+            dir.path().join("v.py").to_str().unwrap(),
+            "--remove",
+            "-S",
+            "db",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("variants"));
+}
+
+#[test]
+fn test_remove_dry_run_leaves_file_unchanged() {
+    let dir = setup_temp_dir_with_files(&[("a.py", REMOVE_FILE)]);
+    let p = dir.path().join("a.py");
+    cmd()
+        .args([
+            p.to_str().unwrap(),
+            "--remove",
+            "-S",
+            "feat1",
+            "--remove-mode",
+            "all",
+            "--dry-run",
+        ])
+        .assert()
+        .success();
+    assert_eq!(std::fs::read_to_string(&p).unwrap(), REMOVE_FILE);
+}

--- a/crates/togl-lib/src/core.rs
+++ b/crates/togl-lib/src/core.rs
@@ -132,6 +132,76 @@ pub fn discover_sections(content: &str) -> Vec<SectionInfo> {
     sections
 }
 
+/// How `remove_section` strips a matched section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoveMode {
+    /// Delete only the two marker lines; keep the body exactly as-is.
+    Markers,
+    /// Delete the markers and any fully-commented body lines; keep live code.
+    Commented,
+    /// Delete the entire span (markers + all body lines).
+    All,
+}
+
+/// Remove every section whose ID exactly equals `id`, per `mode`. Returns the
+/// rewritten content and the number of sections removed. Duplicate IDs within
+/// the file are all removed. A body line counts as "commented" when, after
+/// leading whitespace, it begins with the single-line comment prefix.
+pub fn remove_section(
+    content: &str,
+    id: &str,
+    mode: RemoveMode,
+    comment_style: &CommentStyle,
+) -> (String, usize) {
+    let lines: Vec<&str> = content.lines().collect();
+    let sections: Vec<SectionInfo> = discover_sections(content)
+        .into_iter()
+        .filter(|s| s.id == id)
+        .collect();
+    if sections.is_empty() {
+        return (content.to_string(), 0);
+    }
+
+    let mut delete = vec![false; lines.len()];
+    let prefix = comment_style.single_line.trim();
+    for s in &sections {
+        let start = s.start_line - 1; // 0-based start marker
+        let end = s.end_line - 1; // 0-based end marker
+        match mode {
+            RemoveMode::All => {
+                for slot in delete.iter_mut().take(end + 1).skip(start) {
+                    *slot = true;
+                }
+            }
+            RemoveMode::Markers => {
+                delete[start] = true;
+                delete[end] = true;
+            }
+            RemoveMode::Commented => {
+                delete[start] = true;
+                delete[end] = true;
+                for (k, line) in lines.iter().enumerate().take(end).skip(start + 1) {
+                    if !prefix.is_empty() && line.trim_start().starts_with(prefix) {
+                        delete[k] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    let kept: Vec<&str> = lines
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !delete[*i])
+        .map(|(_, l)| *l)
+        .collect();
+    let mut result = kept.join("\n");
+    if content.ends_with('\n') && !result.is_empty() {
+        result.push('\n');
+    }
+    (result, sections.len())
+}
+
 /// Return all `SectionInfo` whose ID parses into the given group.
 /// `discover_variants(content, "db")` matches both `db` (solo) and `db:postgres` (variant).
 pub fn discover_variants(content: &str, group: &str) -> Vec<SectionInfo> {

--- a/crates/togl-lib/tests/unit/core_tests.rs
+++ b/crates/togl-lib/tests/unit/core_tests.rs
@@ -807,3 +807,70 @@ fn test_insert_section_rejects_inverted_range() {
     let content = "a\nb\nc\n";
     assert!(insert_section(content, "feat", None, 3, 1, "#").is_err());
 }
+
+// ── P06: core::remove_section (markers / commented / all) ──
+
+const REMOVE_FIXTURE: &str =
+    "outside1\n# toggle:start ID=feat1\n# commented_old\nlive_code\n# toggle:end ID=feat1\noutside2\n";
+
+#[test]
+fn test_remove_section_markers_keeps_body() {
+    let (out, n) = togl_lib::core::remove_section(
+        REMOVE_FIXTURE,
+        "feat1",
+        togl_lib::core::RemoveMode::Markers,
+        &comment_style_py(),
+    );
+    assert_eq!(n, 1);
+    assert_eq!(out, "outside1\n# commented_old\nlive_code\noutside2\n");
+}
+
+#[test]
+fn test_remove_section_commented_drops_comments_keeps_live() {
+    let (out, n) = togl_lib::core::remove_section(
+        REMOVE_FIXTURE,
+        "feat1",
+        togl_lib::core::RemoveMode::Commented,
+        &comment_style_py(),
+    );
+    assert_eq!(n, 1);
+    assert_eq!(out, "outside1\nlive_code\noutside2\n");
+}
+
+#[test]
+fn test_remove_section_all_drops_span() {
+    let (out, n) = togl_lib::core::remove_section(
+        REMOVE_FIXTURE,
+        "feat1",
+        togl_lib::core::RemoveMode::All,
+        &comment_style_py(),
+    );
+    assert_eq!(n, 1);
+    assert_eq!(out, "outside1\noutside2\n");
+}
+
+#[test]
+fn test_remove_section_removes_all_duplicate_ids() {
+    let content =
+        "# toggle:start ID=dup\na\n# toggle:end ID=dup\nmid\n# toggle:start ID=dup\nb\n# toggle:end ID=dup\n";
+    let (out, n) = togl_lib::core::remove_section(
+        content,
+        "dup",
+        togl_lib::core::RemoveMode::All,
+        &comment_style_py(),
+    );
+    assert_eq!(n, 2, "both duplicate sections removed");
+    assert_eq!(out, "mid\n");
+}
+
+#[test]
+fn test_remove_section_id_not_found_is_noop() {
+    let (out, n) = togl_lib::core::remove_section(
+        REMOVE_FIXTURE,
+        "missing",
+        togl_lib::core::RemoveMode::All,
+        &comment_style_py(),
+    );
+    assert_eq!(n, 0);
+    assert_eq!(out, REMOVE_FIXTURE);
+}


### PR DESCRIPTION
Implements **P06** from the marker design spec: `--remove -S <ID>` strips a named section, recursively with `-R`.

| `--remove-mode` | Marker lines | Commented body | Live body |
|---|---|---|---|
| `markers` | deleted | kept | kept |
| `commented` *(default)* | deleted | deleted | kept |
| `all` | deleted | deleted | deleted |

- Refuses an ambiguous bare variant group (`-S db` with `db:sqlite`/`db:postgres`)
- `--require-match` exits non-zero on no match; otherwise warns + exits 0
- Removes **all** duplicate-ID pairs in a file; reuses `--dry-run`/`--backup` via `apply_changes`
- Pure `core::remove_section` (TDD: 5 unit tests) + `run_remove` (8 integration tests)

**Out of scope:** `--remove --atomic` (guarded with an error for now) and multi-line-delimited comment detection. Suite: lib 99→104, integration 135→143; clippy + fmt clean.