### PR TITLE
ci: build flake packages on all four Nix platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,34 @@ jobs:
 
       - name: Fail if the committed header is out of date
         run: git diff --exit-code crates/togl-ffi/include/togl.h
+
+  # Build the flake's packages (togl + libtogl) on every supported Nix platform.
+  # The repo CI otherwise only exercises the Rust crates via cargo; this is the
+  # only job that builds the Nix derivations, catching flake/derivation breakage
+  # (e.g. a Cargo.lock change that the committed flake.lock no longer matches).
+  nix:
+    name: Nix build (${{ matrix.system }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+          - runner: macos-15-intel
+            system: x86_64-darwin
+          - runner: macos-latest
+            system: aarch64-darwin
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      # `--no-update-lock-file` keeps the committed flake.lock authoritative:
+      # the build fails rather than silently updating it (portable across Nix
+      # versions; the newer `--locked` isn't available everywhere).
+      - name: Build togl and libtogl
+        run: nix build --no-update-lock-file --print-build-logs '.#togl' '.#libtogl'


### PR DESCRIPTION
Adds a `nix` CI job that builds the flake's `togl` and `libtogl` packages on all four supported Nix platforms:

| Runner | System |
|---|---|
| ubuntu-latest | x86_64-linux |
| ubuntu-24.04-arm | aarch64-linux |
| macos-15-intel | x86_64-darwin |
| macos-latest | aarch64-darwin |

**Why:** the rest of CI only builds the Rust crates via `cargo`; nothing built the Nix derivations on any platform, so flake/derivation breakage (e.g. a `Cargo.lock` change the committed `flake.lock` no longer matches) would only surface later in nixpkgs/ofborg. This closes that gap.

`--no-update-lock-file` keeps the committed `flake.lock` authoritative (build fails rather than silently updating). Verified locally: builds on aarch64-darwin; actionlint clean.