### PR TITLE
ci: publish to crates.io via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,18 +57,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Publish the library and CLI crates to crates.io. `togl-lib` is published
-  # first because `togl` depends on it (cargo waits for it to be available
-  # before the dependent publish). `togl-ffi` is `publish = false`.
+  # Publish the library and CLI crates to crates.io via Trusted Publishing
+  # (OIDC — no stored API token). `togl-lib` is published first because `togl`
+  # depends on it (cargo waits for it to be available). `togl-ffi` is
+  # `publish = false`.
   #
-  # Requires the `CARGO_REGISTRY_TOKEN` secret. Until it is set, this job fails
-  # loudly with a clear message but does not affect the binary-build job above.
+  # Setup (one-time): each published crate (`togl-lib`, `togl`) has a Trusted
+  # Publisher on crates.io pointing at this repo, workflow `release.yml`, and
+  # environment `crates`. The job runs in that environment and mints a
+  # short-lived token via `crates-io-auth-action`; no secret is required.
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    environment: crates
+    permissions:
+      id-token: write # required to mint the OIDC token for trusted publishing
+      contents: read
     steps:
       - name: Validate tag ref
         if: github.ref_type != 'tag'
@@ -80,12 +85,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
-      - name: Require crates.io token
-        run: |
-          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
-            echo "::error::CARGO_REGISTRY_TOKEN secret is not set. Add it under repo Settings → Secrets to enable crates.io publishing."
-            exit 1
-          fi
+      - name: Authenticate to crates.io (trusted publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
 
       # release-please bumps the workspace version but not the inter-crate dep
       # requirement, so pin togl-lib's `version` to this release before publish.
@@ -99,6 +101,10 @@ jobs:
       # release-time edit.
       - name: Publish togl-lib
         run: cargo publish -p togl-lib --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Publish togl
         run: cargo publish -p togl --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -289,12 +289,16 @@ the CLI and auto-publish the library + CLI on each release tag.
 - [x] [P11-T01] Rename CLI package → `togl`; add `version` to `togl-lib` dep/dev-dep;
       `togl-ffi` `publish = false`; update `-p togl-cli` refs (flake, test script)
 - [x] [P11-T02] `publish-crates` job in `release.yml` (sync dep version → tag,
-      publish `togl-lib` then `togl`, `CARGO_REGISTRY_TOKEN`)
+      publish `togl-lib` then `togl`)
+- [x] [P11-T03] Trusted Publishing (OIDC): job runs in `environment: crates` with
+      `id-token: write` + `rust-lang/crates-io-auth-action`; no API-token secret
 - [x] [P11-TS01] `cargo publish --dry-run` (togl-lib full; togl manifest),
       full test suite + `nix build .#togl` green after the rename
 
 ### Manual Steps (maintainer)
-- Add repo secret `CARGO_REGISTRY_TOKEN` (crates.io API token). Until then the
-  publish job fails loudly but does not block the binary build.
-- First publish fires on the next release tag (e.g. v0.6.0); crates.io versions
-  jump 0.2.3 → that release (allowed — versions only need to increase).
+- crates.io uses **Trusted Publishing** (no `CARGO_REGISTRY_TOKEN` secret). Per
+  crate (`togl-lib`, `togl`) add a Trusted Publisher: repo `smorin/toggle`,
+  workflow `release.yml`, environment `crates`. (Done: `togl-lib` bootstrapped
+  with a manual `0.0.0` publish since crates.io TP needs the crate to exist first.)
+- First real publish fires on the next release tag (e.g. v0.6.0); crates.io
+  versions jump 0.2.3 → that release (allowed — versions only need to increase).


### PR DESCRIPTION
Switches the `publish-crates` job to crates.io **Trusted Publishing** (OIDC) — no stored API token.

## Changes to the job
- `environment: crates` (matches the per-crate Trusted Publisher config)
- `permissions: { id-token: write, contents: read }` (mint the OIDC token; the top-level `contents: write` doesn't grant id-token)
- `rust-lang/crates-io-auth-action@bbd8162 # v1.0.4` mints a 30-min token, passed to each `cargo publish` via `CARGO_REGISTRY_TOKEN`
- Removed the `secrets.CARGO_REGISTRY_TOKEN` env + the token-presence check

## Setup state
- ✅ `crates` GitHub environment exists in the repo.
- ✅ `togl-lib` bootstrapped (manual `0.0.0` publish — crates.io TP requires the crate to exist before a Trusted Publisher can be configured; no pending-publisher flow like PyPI).
- ⚠️ **Confirm a Trusted Publisher is configured for _both_ `togl-lib` and `togl`** on crates.io (repo `smorin/toggle`, workflow `release.yml`, environment `crates`). The workflow publishes both, so both need it.

## Notes
- actionlint clean.
- First real publish fires on the next release tag (v0.6.0): the job publishes `togl-lib` then `togl` via OIDC.
- Gotcha: if you add deployment-branch protection to the `crates` environment, allow **tags** — this workflow is tag-triggered, and branch rules can block tag deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security of the release publishing process through updated authentication mechanisms for crate publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->