### PR TITLE
ci: don't persist credentials for read-only nixpkgs checkout

### DIFF
--- a/.github/workflows/nixpkgs-update.yml
+++ b/.github/workflows/nixpkgs-update.yml
@@ -47,6 +47,7 @@ jobs:
           repository: NixOS/nixpkgs
           ref: master
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 


### PR DESCRIPTION
## What

Add `persist-credentials: false` to the `NixOS/nixpkgs` checkout in `.github/workflows/nixpkgs-update.yml`.

## Why

That step checks out `NixOS/nixpkgs` **only to read it** and compute a version bump locally. The resulting PR is pushed to the `smorin/nixpkgs` fork by `peter-evans/create-pull-request` using its own `NIXPKGS_UPDATE_TOKEN` (`push-to-fork`) — never the checkout's persisted credentials. The only other git use is `git diff` (read-only).

By default `actions/checkout` persists the token into `.git/config` after cloning. Since no later step needs it, persisting it only widens the window for a later step to read or misuse the credential. `persist-credentials: false` uses the token for the initial clone only, then strips it.

## Scope notes

- This is the **only** read-only external-repo checkout in the workflows. All other checkouts target the current repo.
- `release-please.yml` was **deliberately left unchanged**: its checkout uses a write token and a later step runs `git push`, which requires the persisted credentials.

## Validation

- Workflow YAML parses cleanly.
- `nixpkgs-update.yml` is `workflow_dispatch`-only, so this change does not affect PR/push CI.
- The version `uses:` pin was not touched.

https://claude.ai/code/session_016wuFKi9GQvDfT6kARKn36F

---
_Generated by [Claude Code](https://claude.ai/code/session_016wuFKi9GQvDfT6kARKn36F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security by preventing credential persistence during repository checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->