### PR TITLE
ci: migrate release-please to client-id auth + bump to @v3

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,57 @@
+# actionlint configuration
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# actionlint v1.7.12 (latest as of 2026-06) ships with stale bundled
+# metadata for `actions/create-github-app-token@v3`. The action accepts
+# a `client-id` input (the modern, preferred auth path; `app-id` is
+# deprecated), but actionlint's schema still only knows about `app-id`.
+#
+# As a result, every workflow that uses the modern `client-id` form
+# trips TWO false positives from actionlint's `action` check:
+#
+#   1. `input "client-id" is not defined in action
+#      "actions/create-github-app-token@v3"`
+#   2. `missing input "app-id" which is required by action
+#      "actions/create-github-app-token@v3"`
+#
+# Both are the same root-cause stale-metadata bug.
+#
+# UPSTREAM TRACKING
+# -----------------
+# Fixes are in flight upstream but not yet released:
+#   - rhysd/actionlint#652 (PR)
+#   - rhysd/actionlint#668 (PR)
+#   - rhysd/actionlint#648 (issue)
+#   - rhysd/actionlint#669 (issue)
+#
+# EXPIRATION
+# ----------
+# DELETE THIS FILE once a newer actionlint release ships with updated
+# bundled metadata for `actions/create-github-app-token@v3`'s
+# `client-id` input. To check: run `actionlint` against
+# `.github/workflows/release-please.yml` with the new version, with
+# this file removed — it should exit 0.
+#
+# SCOPE
+# -----
+# The suppression is narrowly scoped to the workflow that uses
+# `create-github-app-token@v3` with `client-id`. All other actionlint
+# checks remain active, both globally and on this file.
+
+self-hosted-runner:
+  labels: []
+
+config-variables: null
+
+paths:
+  .github/workflows/release-please.yml:
+    ignore:
+      # False positive: action accepts `client-id` (stale actionlint schema).
+      - >-
+          input "client-id" is not defined in action
+          "actions/create-github-app-token@v3"
+      # False positive: `app-id` is only required when `client-id` is absent.
+      - >-
+          missing input "app-id" which is required by action
+          "actions/create-github-app-token@v3"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,10 @@
 # workflows (release.yml builds binaries on the v* tag) — GITHUB_TOKEN is
 # intentionally NOT used as a fallback, since it never triggers downstream
 # workflows and may be blocked from opening PRs by org policy:
-#   1. GitHub App (preferred): set RELEASE_PLEASE_APP_ID + RELEASE_PLEASE_PRIVATE_KEY
-#      (App with Contents + Pull requests: write); both jobs mint an installation
-#      token from them.
+#   1. GitHub App (preferred): set RELEASE_PLEASE_CLIENT_ID + RELEASE_PLEASE_PRIVATE_KEY
+#      (App with Contents + Pull requests: write). Client ID is the modern
+#      (non-deprecated) input name for actions/create-github-app-token@v3;
+#      both jobs mint an installation token from these values.
 #   2. Fallback PAT: set RELEASE_PLEASE_APP_TOKEN (fine-grained PAT, Contents +
 #      Pull requests: write).
 # See RELEASE.md for setup. With neither configured, release-please fails fast.
@@ -34,7 +35,7 @@ jobs:
     env:
       # Surfaced so the app-token step's `if:` can test it (secrets are not
       # available directly in `if:` conditions). Empty unless the App is set up.
-      RP_APP_ID: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+      RP_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       pr: ${{ steps.rp.outputs.pr }}
@@ -43,10 +44,10 @@ jobs:
       # release PR/tag triggers downstream workflows. Skipped otherwise.
       - name: Mint release-please app token
         id: app-token
-        if: ${{ env.RP_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
+        if: ${{ env.RP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - name: release-please
@@ -71,17 +72,17 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      RP_APP_ID: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+      RP_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
     steps:
       # Mint a fresh installation token from the same App (a separate token —
       # steps don't cross jobs) so the Cargo.lock sync commit pushed to the
       # release PR branch also triggers its CI checks.
       - name: Mint release-please app token
         id: app-token
-        if: ${{ env.RP_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
+        if: ${{ env.RP_CLIENT_ID != '' }}
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - name: Checkout release PR branch


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token` from `@v2` to `@v3` (v2 doesn't accept the modern `client-id` input).
- Switch auth from `RELEASE_PLEASE_APP_ID` (deprecated `app-id` input) to `RELEASE_PLEASE_CLIENT_ID` (modern `client-id` input) in both `release-please` and `sync-cargo-lock` jobs.
- Add `.github/actionlint.yaml` to suppress two false positives from actionlint's stale bundled metadata for `create-github-app-token@v3` (it doesn't yet know about `client-id`).
- `RELEASE_PLEASE_APP_TOKEN` PAT fallback preserved unchanged.

Aligns toggle with the org-wide migration (smorinlabs sibling repos + `smorin/doxa-research`). After merge + green verification run, the legacy `RELEASE_PLEASE_APP_ID` secret will be deleted.

## Test plan
- [ ] CI green on the PR
- [ ] After merge, push an empty `ci:` commit to main and verify the release-please workflow's `Mint release-please app token` step succeeds with `client-id` and emits zero deprecation warnings
- [ ] Delete `RELEASE_PLEASE_APP_ID` secret after green verification