### PR TITLE
fix: use schema-valid 'default' object in .contributors.yml

### DIFF
--- a/.contributors.yml
+++ b/.contributors.yml
@@ -33,4 +33,6 @@ classification:
         - "tests/**"
         - "benches/**"
         - "nix/**"
-  default_category: code
+  default:
+    id: code
+    label: Code Contributor

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -344,8 +344,10 @@ contributors-please.
       no-cancel concurrency; ship both bins in `togl-<target>` archives
 - [x] [P12-T05] contributors-please: update-contributors.yml,
       .contributors.yml, CONTRIBUTORS.md markers
-- [ ] [P12-TS01] Pre-release tag (vX.Y.Z-rc.1) exercises the pipeline
-      end-to-end before the first real release
+- [ ] [P12-TS01] First gated release exercises the pipeline end-to-end
+      (an rc tag would fail the tag==version guard without a matching
+      version-bump commit, and npm would tag the rc `latest`; the
+      environment reviewer gates + TestPyPI smoke test cover the risk)
 
 ### Manual Steps (maintainer)
 - PyPI + TestPyPI: add trusted publisher per registry for `togl`


### PR DESCRIPTION
First Update Contributors run failed: `Unknown config key(s): /classification/default_category`. The schema requires `classification.default` as an `{id, label}` object (cross-checked against smorinlabs/py-launch-blueprint's working config). https://claude.ai/code/session_014DjTALJi3LJhYmrdpw6Rej

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/smorin/toggle/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

