### PR TITLE
fix(release): skip already-published npm packages so job reruns are idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,18 +329,31 @@ jobs:
             "optionalDependencies.@smorinlabs/togl-win32-x64=${VERSION}")
 
       # Platform packages first — the wrapper's optionalDependencies must be
-      # resolvable the moment it lands.
+      # resolvable the moment it lands. Skip versions already on the registry
+      # so a partial-failure rerun is idempotent (npm hard-rejects publishing
+      # over an existing version).
       - name: Publish platform packages
         run: |
           set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
           for plat in linux-x64 darwin-x64 darwin-arm64 win32-x64; do
+            pkg="@smorinlabs/togl-${plat}"
+            if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${pkg}@${VERSION} already published — skipping"
+              continue
+            fi
             (cd "npm/platform/${plat}" && npm publish --access public)
           done
 
       - name: Publish togl-cli
         run: |
           set -euo pipefail
-          cd npm/togl-cli && npm publish
+          VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "togl-cli@${VERSION}" version >/dev/null 2>&1; then
+            echo "togl-cli@${VERSION} already published — skipping"
+          else
+            cd npm/togl-cli && npm publish
+          fi
 
   # Bump the prebuilt-binary formula in smorinlabs/homebrew-tap. The push
   # authenticates with a short-lived App installation token minted in-job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
npm hard-rejects publishing over an existing version, so a rerun of a partially-failed `publish-npm` job dies on the platform packages before reaching `togl-cli` (exactly what happened on v0.5.1: all four platform packages published with provenance, then the wrapper's stale trusted-publisher config failed it, and reruns were blocked). Each publish now checks the registry first and skips existing versions — the npm equivalent of `uv publish --check-url`.

Merging this as `fix:` triggers the v0.5.2 release PR, whose gated release will publish all five npm packages (wrapper included) via OIDC — completing the npm destination and validating the corrected trusted publishers end to end.

https://claude.ai/code/session_014DjTALJi3LJhYmrdpw6Rej

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/smorin/toggle/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing to safely handle previously published package versions.
  * Prevents duplicate publication attempts for platform packages and the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->