### PR TITLE
ci: disable debug info on windows test builds to eliminate LNK1201 PDB flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # LNK1201 ("error writing to program database") is an intermittent MSVC
+      # linker failure writing PDB debug-symbol files on shared runners. CI
+      # test runs never consume PDBs, so disable debug info on Windows —
+      # no PDB is written and the failure mode cannot occur (also trims
+      # build time and cache size). Linux/macOS keep the default.
+      CARGO_PROFILE_DEV_DEBUG: ${{ matrix.os == 'windows-latest' && '0' || 'true' }}
+      CARGO_PROFILE_TEST_DEBUG: ${{ matrix.os == 'windows-latest' && '0' || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
LNK1201 is an intermittent MSVC linker failure writing PDB debug-symbol files on shared runners (file locks/AV/stale cache) — a pure infrastructure flake: the same commit failed twice and passed on rerun with no changes. CI test runs never consume PDBs, so this sets `debuginfo=0` on the Windows leg only (via `CARGO_PROFILE_DEV_DEBUG`/`CARGO_PROFILE_TEST_DEBUG` matrix expressions): the PDB is never written, making LNK1201 impossible rather than less likely. Bonus: faster Windows builds, smaller cache. Linux/macOS legs unchanged (full debug info retained). `ci:` type — no release triggered.

https://claude.ai/code/session_014DjTALJi3LJhYmrdpw6Rej

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/smorin/toggle/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

